### PR TITLE
chore: rename npm scope from @agentfi to @agent_fi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,19 +52,19 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
-    "node_modules/@agentfi/adapters": {
+    "node_modules/@agent_fi/adapters": {
       "resolved": "packages/adapters",
       "link": true
     },
-    "node_modules/@agentfi/admin": {
+    "node_modules/@agent_fi/admin": {
       "resolved": "packages/admin",
       "link": true
     },
-    "node_modules/@agentfi/backend": {
+    "node_modules/@agent_fi/backend": {
       "resolved": "packages/backend",
       "link": true
     },
-    "node_modules/@agentfi/mcp-server": {
+    "node_modules/@agent_fi/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
     },
@@ -11261,7 +11261,7 @@
       }
     },
     "packages/adapters": {
-      "name": "@agentfi/adapters",
+      "name": "@agent_fi/adapters",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -11282,7 +11282,7 @@
       }
     },
     "packages/admin": {
-      "name": "@agentfi/admin",
+      "name": "@agent_fi/admin",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -11331,7 +11331,7 @@
       }
     },
     "packages/backend": {
-      "name": "@agentfi/backend",
+      "name": "@agent_fi/backend",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -11396,7 +11396,7 @@
       "license": "MIT"
     },
     "packages/mcp-server": {
-      "name": "@agentfi/mcp-server",
+      "name": "@agent_fi/mcp-server",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentfi/adapters",
+  "name": "@agent_fi/adapters",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/adapters" },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentfi/admin",
+  "name": "@agent_fi/admin",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/admin" },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentfi/backend",
+  "name": "@agent_fi/backend",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/backend" },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentfi/mcp-server",
+  "name": "@agent_fi/mcp-server",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },


### PR DESCRIPTION
## Summary
- npm org `agentfi` was unavailable, created `agent_fi` instead
- Updated all 4 package names: mcp-server, adapters, admin, backend

## Test plan
- [ ] CI passes (typecheck, tests)
- [ ] `npm publish --access public` succeeds with new scope