### PR TITLE
feat(phase3): Compound V3 + Reputation time-decay + Daily cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Reputation Scoring v2.1 (time-decay)**: recent 30-day transactions and job outcomes now carry 2x weight vs historical events
+- **Daily Reputation Cron**: BullMQ repeatable job recomputes all active agents' scores daily at 02:00 UTC (override via `REPUTATION_CRON_PATTERN`)
+- `packages/backend/src/queues/reputation.queue.ts` — new queue, worker, and `scheduleReputationUpdate()`
+- **Compound V3 integration**: `POST /v1/transactions/supply-compound` and `POST /v1/transactions/withdraw-compound`
+- `TransactionBuilder.buildCompoundSupply()` and `buildCompoundWithdraw()` methods
+- `COMPOUND_COMET_ABI` constant for Comet market contracts
+- Compound V3 USDC market addresses added to `contracts.ts` (Mainnet, Base, Arbitrum, Polygon)
 - **Reputation Scoring v2**: computed from real behavior metrics (tx success rate 40%, job completion rate 30%, volume score 20%, consistency 10%) instead of simple counter
 - `ReputationService.computeReputationScore()`, `refreshReputation()`, `updateAllReputationScores()`
 - Admin endpoints: `POST /admin/reputation/recompute` (all or single agent), `GET /admin/reputation/:agentId` (shows persisted vs computed drift)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -74,6 +74,8 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 | POST | `/v1/transactions/transfer` | Agent | ETH or ERC-20 transfer |
 | POST | `/v1/transactions/deposit` | Agent | Supply to Aave V3 |
 | POST | `/v1/transactions/withdraw` | Agent | Withdraw from Aave V3 |
+| POST | `/v1/transactions/supply-compound` | Agent | Supply to Compound V3 (Comet USDC market) |
+| POST | `/v1/transactions/withdraw-compound` | Agent | Withdraw from Compound V3 |
 | POST | `/v1/transactions/batch` | Agent | Multi-call batch (max 20 actions) |
 | GET | `/v1/transactions/:id` | Agent (owner) | Transaction status |
 | GET | `/v1/transactions` | Agent | Paginated history |
@@ -151,6 +153,8 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | POST | `/admin/transactions/:id/reject` | Reject PENDING_APPROVAL tx |
 | GET | `/admin/volume` | Daily volume chart (7 days) |
 | GET | `/admin/revenue` | Revenue breakdown by tier |
+| POST | `/admin/reputation/recompute` | Recompute reputation (all or single agent via body) |
+| GET | `/admin/reputation/:agentId` | Reputation detail with persisted vs computed drift |
 
 ---
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -67,18 +67,18 @@ These items bridge the gap between the current product (agent-to-DeFi) and the v
   - Implement `verify-handshake` via EIP-1271 (Safe wallets) + ECDSA recovery (EOA fallback)
   - Enable agents to cryptographically prove identity to peers
 
-- [x] **Reputation Scoring v2** (April 2026):
+- [x] **Reputation Scoring v2 + time-decay** (April 2026):
   - [x] Weighted score derived from: tx success rate (40%), job completion rate (30%), volume (20%), consistency (10%)
   - [x] Admin endpoints for recompute and drift inspection
   - [x] `computeReputationScore()` returns 0–10,000 integer score
-  - [ ] Time-decay weighting (recent behavior > historical) — v3
-  - [ ] Daily cron job for automatic recompute — v3
+  - [x] Time-decay weighting: recent 30 days carry 2x weight vs historical
+  - [x] Daily BullMQ repeatable job for automatic recompute (02:00 UTC default)
 
 - **DeFi Protocol Expansion:**
-  - Compound V3 (supply/borrow)
-  - Curve Finance (stablecoin swaps)
-  - GMX / Perp DEXes (for advanced agents)
-  - ERC-4626 vault standard (generic yield)
+  - [x] Compound V3 (supply/withdraw) — Mainnet, Base, Arbitrum, Polygon
+  - [ ] Curve Finance (stablecoin swaps)
+  - [ ] GMX / Perp DEXes (for advanced agents)
+  - [ ] ERC-4626 vault standard (generic yield)
   - More earning paths = closer to self-sustaining agents
 
 - **Fastify v4 to v5 Migration:**

--- a/packages/backend/src/api/routes/transactions.ts
+++ b/packages/backend/src/api/routes/transactions.ts
@@ -808,6 +808,244 @@ export async function transactionRoutes(fastify: FastifyInstance) {
   });
 
   /**
+   * POST /v1/transactions/supply-compound
+   * Supplies an asset to Compound V3 (Comet USDC market).
+   */
+  fastify.post('/v1/transactions/supply-compound', async (request, reply) => {
+    const body = depositSchema.parse(request.body);
+    const agent = await getAgent(request.agentId);
+    if (!ensureChainAllowed(agent, body.chainId, reply)) return;
+
+    if (body.idempotencyKey) {
+      const idempotent = await getIdempotentTransaction(request.agentId, body.idempotencyKey);
+      if (idempotent.existing) return idempotent.existing;
+      if (idempotent.conflictWithAnotherAgent) {
+        return reply.code(409).send({ error: 'idempotencyKey is already in use by another agent' });
+      }
+    }
+
+    const withinLimit = await feeService.checkTxLimit(request.agentId, request.agentTier);
+    if (!withinLimit) {
+      return reply.code(429).send({ error: 'Monthly transaction limit reached' });
+    }
+
+    const contracts = getContracts(body.chainId);
+    if (!contracts.compoundCometUsdc) {
+      return reply.code(400).send({ error: `Compound V3 not configured for chain ${body.chainId}` });
+    }
+
+    const decimals = await getTokenDecimals(body.asset, body.chainId);
+    const amountWei = parseUnits(body.amount, decimals);
+
+    const supplyTx = builder.buildCompoundSupply({
+      cometAddress: contracts.compoundCometUsdc,
+      asset: getAddress(body.asset),
+      amount: amountWei,
+    });
+
+    const lastTxTimestamp = await getLatestAgentTxTimestamp(request.agentId);
+    const valueUsd = await tokenAmountToUsd(amountWei, body.asset, decimals, body.chainId);
+    const policyResult = await policyService.validateTransaction({
+      agentId: request.agentId,
+      targetContract: supplyTx.to,
+      tokenAddress: getAddress(body.asset),
+      valueEth: '0',
+      valueUsd,
+      ...(lastTxTimestamp !== undefined ? { lastTxTimestamp } : {}),
+    });
+    if (!policyResult.allowed) {
+      return reply.code(403).send({ error: policyResult.reason });
+    }
+
+    const sim = await simulator.simulate({
+      chainId: body.chainId,
+      from: getAddress(agent.safeAddress),
+      to: supplyTx.to,
+      data: supplyTx.data,
+      value: supplyTx.value,
+    });
+    if (!sim.success) {
+      return reply.code(422).send({ error: `Simulation failed: ${sim.error}` });
+    }
+
+    const feeCalc = feeService.calculateFee({ grossAmountWei: amountWei, tier: request.agentTier });
+
+    const tx = await db.transaction.create({
+      data: {
+        agentId: request.agentId,
+        idempotencyKey: body.idempotencyKey ?? null,
+        chainId: body.chainId,
+        status: policyResult.requiresApproval ? 'PENDING_APPROVAL' : 'QUEUED',
+        type: 'DEPOSIT',
+        fromToken: body.asset,
+        amountIn: body.amount,
+        simulation: sim as any,
+        metadata: {
+          protocol: 'compound-v3',
+          queuePayload: {
+            to: supplyTx.to,
+            data: supplyTx.data,
+            value: supplyTx.value.toString(),
+            feeAmountWei: feeCalc.feeAmountWei.toString(),
+            feeBps: feeCalc.feeBps,
+            routedViaExecutor: false,
+          },
+        },
+      },
+    });
+
+    if (!policyResult.requiresApproval) {
+      await transactionQueue.add('compound-supply', {
+        transactionId: tx.id,
+        chainId: body.chainId,
+        walletId: agent.walletId,
+        from: getAddress(agent.safeAddress),
+        to: supplyTx.to,
+        data: supplyTx.data,
+        value: supplyTx.value.toString(),
+        agentId: request.agentId,
+        tier: request.agentTier,
+        feeAmountWei: feeCalc.feeAmountWei.toString(),
+        feeUsd: '0',
+        feeBps: feeCalc.feeBps,
+        routedViaExecutor: false,
+      });
+    } else {
+      await notificationService.notify({
+        type: 'PENDING_APPROVAL',
+        agentId: request.agentId,
+        agentName: agent.name,
+        transactionId: tx.id,
+        message: `Compound supply (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
+      });
+    }
+
+    return reply.code(202).send({ transactionId: tx.id, status: tx.status });
+  });
+
+  /**
+   * POST /v1/transactions/withdraw-compound
+   * Withdraws an asset from Compound V3 (Comet USDC market).
+   */
+  fastify.post('/v1/transactions/withdraw-compound', async (request, reply) => {
+    const body = withdrawSchema.parse(request.body);
+    const agent = await getAgent(request.agentId);
+    if (!ensureChainAllowed(agent, body.chainId, reply)) return;
+
+    if (body.idempotencyKey) {
+      const idempotent = await getIdempotentTransaction(request.agentId, body.idempotencyKey);
+      if (idempotent.existing) return idempotent.existing;
+      if (idempotent.conflictWithAnotherAgent) {
+        return reply.code(409).send({ error: 'idempotencyKey is already in use by another agent' });
+      }
+    }
+
+    const withinLimit = await feeService.checkTxLimit(request.agentId, request.agentTier);
+    if (!withinLimit) {
+      return reply.code(429).send({ error: 'Monthly transaction limit reached' });
+    }
+
+    const contracts = getContracts(body.chainId);
+    if (!contracts.compoundCometUsdc) {
+      return reply.code(400).send({ error: `Compound V3 not configured for chain ${body.chainId}` });
+    }
+
+    const decimals = await getTokenDecimals(body.asset, body.chainId);
+    const amountWei = body.amount === 'max' ? maxUint256 : parseUnits(body.amount, decimals);
+
+    const withdrawTx = builder.buildCompoundWithdraw({
+      cometAddress: contracts.compoundCometUsdc,
+      asset: getAddress(body.asset),
+      amount: amountWei,
+    });
+
+    const lastTxTimestamp = await getLatestAgentTxTimestamp(request.agentId);
+    const valueUsd =
+      body.amount === 'max'
+        ? '0'
+        : await tokenAmountToUsd(amountWei, body.asset, decimals, body.chainId);
+    const policyResult = await policyService.validateTransaction({
+      agentId: request.agentId,
+      targetContract: withdrawTx.to,
+      tokenAddress: getAddress(body.asset),
+      valueEth: '0',
+      valueUsd,
+      ...(lastTxTimestamp !== undefined ? { lastTxTimestamp } : {}),
+    });
+    if (!policyResult.allowed) {
+      return reply.code(403).send({ error: policyResult.reason });
+    }
+
+    const sim = await simulator.simulate({
+      chainId: body.chainId,
+      from: getAddress(agent.safeAddress),
+      to: withdrawTx.to,
+      data: withdrawTx.data,
+      value: withdrawTx.value,
+    });
+    if (!sim.success) {
+      return reply.code(422).send({ error: `Simulation failed: ${sim.error}` });
+    }
+
+    const feeCalc = feeService.calculateFee({
+      grossAmountWei: 0n,
+      tier: request.agentTier,
+    });
+
+    const tx = await db.transaction.create({
+      data: {
+        agentId: request.agentId,
+        idempotencyKey: body.idempotencyKey ?? null,
+        chainId: body.chainId,
+        status: policyResult.requiresApproval ? 'PENDING_APPROVAL' : 'QUEUED',
+        type: 'WITHDRAW',
+        fromToken: body.asset,
+        amountIn: body.amount,
+        simulation: sim as any,
+        metadata: {
+          protocol: 'compound-v3',
+          queuePayload: {
+            to: withdrawTx.to,
+            data: withdrawTx.data,
+            value: withdrawTx.value.toString(),
+            feeAmountWei: feeCalc.feeAmountWei.toString(),
+            feeBps: feeCalc.feeBps,
+            routedViaExecutor: false,
+          },
+        },
+      },
+    });
+
+    if (!policyResult.requiresApproval) {
+      await transactionQueue.add('compound-withdraw', {
+        transactionId: tx.id,
+        chainId: body.chainId,
+        walletId: agent.walletId,
+        from: getAddress(agent.safeAddress),
+        to: withdrawTx.to,
+        data: withdrawTx.data,
+        value: withdrawTx.value.toString(),
+        agentId: request.agentId,
+        tier: request.agentTier,
+        feeAmountWei: feeCalc.feeAmountWei.toString(),
+        feeUsd: '0',
+        feeBps: feeCalc.feeBps,
+        routedViaExecutor: false,
+      });
+    } else {
+      await notificationService.notify({
+        type: 'PENDING_APPROVAL',
+        agentId: request.agentId,
+        agentName: agent.name,
+        transactionId: tx.id,
+        message: `Compound withdraw (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
+      });
+    }
+
+    return reply.code(202).send({ transactionId: tx.id, status: tx.status });
+  });
+
+  /**
    * POST /v1/transactions/batch — execute multiple raw calldata actions atomically.
    *
    * Each action maps directly to AgentExecutor.Action: { to, value, data }.

--- a/packages/backend/src/config/contracts.ts
+++ b/packages/backend/src/config/contracts.ts
@@ -8,6 +8,8 @@ interface ChainContracts {
   uniswapV3Quoter: Address;
   // Aave V3 addresses
   aavePoolAddressProvider: Address;
+  // Compound V3 (Comet) USDC market address. One per chain.
+  compoundCometUsdc?: Address | undefined;
 }
 
 export const CONTRACT_ADDRESSES: Record<number, ChainContracts> = {
@@ -18,6 +20,7 @@ export const CONTRACT_ADDRESSES: Record<number, ChainContracts> = {
     uniswapV3Router: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
     uniswapV3Quoter: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
     aavePoolAddressProvider: '0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e',
+    compoundCometUsdc: '0xc3d688B66703497DAA19211EEdff47f25384cdc3',
   },
   // Base
   8453: {
@@ -26,6 +29,7 @@ export const CONTRACT_ADDRESSES: Record<number, ChainContracts> = {
     uniswapV3Router: '0x2626664c2603336E57B271c5C0b26F421741e481',
     uniswapV3Quoter: '0x3d4e44Eb1374240CE5F1B136CFc5b5e8b4e1b2f7',
     aavePoolAddressProvider: '0xe20fCBdBfFC4Dd138cE8b2E6FBb6CB49777ad64B',
+    compoundCometUsdc: '0xb125E6687d4313864e53df431d5425969c15Eb2F',
   },
   // Arbitrum One
   42161: {
@@ -34,6 +38,7 @@ export const CONTRACT_ADDRESSES: Record<number, ChainContracts> = {
     uniswapV3Router: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
     uniswapV3Quoter: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
     aavePoolAddressProvider: '0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb',
+    compoundCometUsdc: '0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf',
   },
   // Base Sepolia (testnet)
   84532: {
@@ -50,6 +55,7 @@ export const CONTRACT_ADDRESSES: Record<number, ChainContracts> = {
     uniswapV3Router: '0xE592427A0AEce92De3Edee1F18E0157C05861564',
     uniswapV3Quoter: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
     aavePoolAddressProvider: '0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb',
+    compoundCometUsdc: '0xF25212E676D1F7F89Cd72fFEe66158f541246445',
   },
 };
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,6 +14,7 @@ import { adminRoutes } from './api/routes/admin.js';
 import { mcpRoutes } from './api/routes/mcp.js';
 import { jobRoutes } from './api/routes/jobs.js';
 import { startTransactionWorker } from './queues/transaction.queue.js';
+import { startReputationWorker, scheduleReputationUpdate } from './queues/reputation.queue.js';
 
 const fastify = Fastify({ logger: logger as any });
 
@@ -94,10 +95,21 @@ async function start() {
     logger.warn('Transaction worker disabled for this process (TRANSACTION_WORKER_ENABLED=false)');
   }
 
+  // Reputation daily cron worker (BullMQ repeatable job).
+  // Non-fatal if Redis is temporarily unavailable — retries on reconnect.
+  let reputationWorker: ReturnType<typeof startReputationWorker> | undefined;
+  try {
+    reputationWorker = startReputationWorker();
+    await scheduleReputationUpdate();
+  } catch (err) {
+    logger.error({ err }, 'Reputation worker failed to start');
+  }
+
   // Graceful shutdown
   const shutdown = async () => {
     logger.info('Shutting down...');
     if (worker) await worker.close();
+    if (reputationWorker) await reputationWorker.close();
     await fastify.close();
     process.exit(0);
   };

--- a/packages/backend/src/queues/reputation.queue.ts
+++ b/packages/backend/src/queues/reputation.queue.ts
@@ -1,0 +1,87 @@
+/**
+ * Reputation Queue — BullMQ repeatable job for daily reputation score recompute.
+ *
+ * Runs `ReputationService.updateAllReputationScores()` on a fixed schedule.
+ * Default: daily at 02:00 UTC. Override via env REPUTATION_CRON_PATTERN.
+ */
+
+import { Queue, Worker } from 'bullmq';
+import { env } from '../config/env.js';
+import { ReputationService } from '../services/policy/reputation.service.js';
+import { logger } from '../api/middleware/logger.js';
+
+const connection = {
+  url: env.REDIS_URL,
+  maxRetriesPerRequest: null as unknown as number,
+  enableReadyCheck: false,
+};
+
+const REPUTATION_QUEUE_NAME = 'reputation';
+
+// Daily at 02:00 UTC by default. Override via env if needed.
+const CRON_PATTERN = process.env['REPUTATION_CRON_PATTERN'] ?? '0 2 * * *';
+
+export const reputationQueue = new Queue(REPUTATION_QUEUE_NAME, {
+  connection,
+  defaultJobOptions: {
+    attempts: 2,
+    backoff: { type: 'exponential', delay: 30_000 },
+    removeOnComplete: { count: 30 },
+    removeOnFail: { count: 100 },
+  },
+});
+
+/**
+ * Schedules the daily repeatable job. Idempotent — BullMQ dedupes by job key.
+ */
+export async function scheduleReputationUpdate(): Promise<void> {
+  await reputationQueue.add(
+    'daily-reputation-update',
+    {},
+    {
+      repeat: { pattern: CRON_PATTERN, tz: 'UTC' },
+      jobId: 'daily-reputation-update', // prevents duplicates on restart
+    },
+  );
+  logger.info(
+    { pattern: CRON_PATTERN, queue: REPUTATION_QUEUE_NAME },
+    'Reputation update cron scheduled',
+  );
+}
+
+/**
+ * Starts a worker that processes reputation update jobs.
+ * Returns the worker so callers can close it on shutdown.
+ */
+export function startReputationWorker(): Worker {
+  const reputationService = new ReputationService();
+
+  const worker = new Worker(
+    REPUTATION_QUEUE_NAME,
+    async () => {
+      const result = await reputationService.updateAllReputationScores();
+      return result;
+    },
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
+
+  worker.on('completed', (job, result) => {
+    logger.info(
+      { jobId: job.id, result },
+      'Reputation update job completed',
+    );
+  });
+
+  worker.on('failed', (job, err) => {
+    logger.error(
+      { jobId: job?.id, err: err?.message ?? String(err) },
+      'Reputation update job failed',
+    );
+  });
+
+  logger.info({ queue: REPUTATION_QUEUE_NAME }, 'Reputation worker started');
+  return worker;
+}

--- a/packages/backend/src/services/policy/reputation.service.ts
+++ b/packages/backend/src/services/policy/reputation.service.ts
@@ -59,23 +59,54 @@ export class ReputationService {
     });
     if (!agent) return 0;
 
-    // 1. Transaction success rate (40%)
-    const [confirmed, failed, reverted] = await Promise.all([
-      db.transaction.count({ where: { agentId, status: 'CONFIRMED' } }),
-      db.transaction.count({ where: { agentId, status: 'FAILED' } }),
-      db.transaction.count({ where: { agentId, status: 'REVERTED' } }),
-    ]);
-    const totalTx = confirmed + failed + reverted;
-    const txSuccessRate = totalTx > 0 ? confirmed / totalTx : 0;
+    // 1. Transaction success rate (40%) — time-decayed: last 30 days weighted 2x
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const [confirmed, failed, reverted, recentConfirmed, recentFailed, recentReverted] =
+      await Promise.all([
+        db.transaction.count({ where: { agentId, status: 'CONFIRMED' } }),
+        db.transaction.count({ where: { agentId, status: 'FAILED' } }),
+        db.transaction.count({ where: { agentId, status: 'REVERTED' } }),
+        db.transaction.count({
+          where: { agentId, status: 'CONFIRMED', createdAt: { gte: thirtyDaysAgo } },
+        }),
+        db.transaction.count({
+          where: { agentId, status: 'FAILED', createdAt: { gte: thirtyDaysAgo } },
+        }),
+        db.transaction.count({
+          where: { agentId, status: 'REVERTED', createdAt: { gte: thirtyDaysAgo } },
+        }),
+      ]);
+    const olderConfirmed = confirmed - recentConfirmed;
+    const olderFailed = failed - recentFailed;
+    const olderReverted = reverted - recentReverted;
+    // Recent events get 2x weight, older get 1x.
+    const weightedSuccess = recentConfirmed * 2 + olderConfirmed;
+    const weightedTotal =
+      (recentConfirmed + recentFailed + recentReverted) * 2 +
+      olderConfirmed +
+      olderFailed +
+      olderReverted;
+    const txSuccessRate = weightedTotal > 0 ? weightedSuccess / weightedTotal : 0;
 
-    // 2. Job completion rate as provider (30%)
-    const [completedJobs, failedJobs] = await Promise.all([
-      db.job.count({ where: { providerId: agentId, status: 'COMPLETED' } }),
-      db.job.count({ where: { providerId: agentId, status: 'FAILED' } }),
-    ]);
-    const totalJobs = completedJobs + failedJobs;
+    // 2. Job completion rate as provider (30%) — also time-decayed (2x recent)
+    const [completedJobs, failedJobs, recentCompletedJobs, recentFailedJobs] =
+      await Promise.all([
+        db.job.count({ where: { providerId: agentId, status: 'COMPLETED' } }),
+        db.job.count({ where: { providerId: agentId, status: 'FAILED' } }),
+        db.job.count({
+          where: { providerId: agentId, status: 'COMPLETED', updatedAt: { gte: thirtyDaysAgo } },
+        }),
+        db.job.count({
+          where: { providerId: agentId, status: 'FAILED', updatedAt: { gte: thirtyDaysAgo } },
+        }),
+      ]);
+    const olderCompletedJobs = completedJobs - recentCompletedJobs;
+    const olderFailedJobs = failedJobs - recentFailedJobs;
+    const weightedJobSuccess = recentCompletedJobs * 2 + olderCompletedJobs;
+    const weightedJobTotal =
+      (recentCompletedJobs + recentFailedJobs) * 2 + olderCompletedJobs + olderFailedJobs;
     // Neutral score (0.5) if no jobs yet — don't penalize new agents
-    const jobCompletionRate = totalJobs > 0 ? completedJobs / totalJobs : 0.5;
+    const jobCompletionRate = weightedJobTotal > 0 ? weightedJobSuccess / weightedJobTotal : 0.5;
 
     // 3. Volume score (20%) — derived from collected fees
     const billing = await db.agentBilling.findUnique({
@@ -91,9 +122,7 @@ export class ReputationService {
       1,
     );
 
-    // 4. Activity consistency (10%) — unique active days in last 30 days
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    // 4. Activity consistency (10%) — unique active days in last 30 days (reuses thirtyDaysAgo)
     const recentTxs = await db.transaction.findMany({
       where: { agentId, createdAt: { gte: thirtyDaysAgo } },
       select: { createdAt: true },

--- a/packages/backend/src/services/transaction/builder.service.ts
+++ b/packages/backend/src/services/transaction/builder.service.ts
@@ -79,6 +79,32 @@ const AAVE_POOL_ABI = [
   },
 ] as const;
 
+// Compound V3 (Comet) ABI — single-asset market contracts.
+// supply(asset, amount): supplies collateral OR base asset to the Comet market.
+// withdraw(asset, amount): withdraws base asset (or collateral) back to msg.sender.
+const COMPOUND_COMET_ABI = [
+  {
+    name: 'supply',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'asset', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'withdraw',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'asset', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+] as const;
+
 // Uniswap V3 SwapRouter02 ABI â€” exactInputSingle WITHOUT deadline.
 // SwapRouter02 moves deadline to the multicall wrapper level.
 // Deployed at 0x2626664c2603336E57B271c5C0b26F421741e481 on Base/Arbitrum/Polygon.
@@ -209,6 +235,46 @@ export class TransactionBuilder {
         abi: AAVE_POOL_ABI,
         functionName: 'withdraw',
         args: [params.asset, params.amount, params.to],
+      }),
+      value: 0n,
+    };
+  }
+
+  /**
+   * Builds a Compound V3 (Comet) supply transaction.
+   * Each Comet market is single-asset (e.g. cUSDCv3 on Base).
+   */
+  buildCompoundSupply(params: {
+    cometAddress: Address;
+    asset: Address;
+    amount: bigint;
+  }): TransactionData {
+    return {
+      to: params.cometAddress,
+      data: encodeFunctionData({
+        abi: COMPOUND_COMET_ABI,
+        functionName: 'supply',
+        args: [params.asset, params.amount],
+      }),
+      value: 0n,
+    };
+  }
+
+  /**
+   * Builds a Compound V3 (Comet) withdraw transaction.
+   * Use MaxUint256 to withdraw the full balance.
+   */
+  buildCompoundWithdraw(params: {
+    cometAddress: Address;
+    asset: Address;
+    amount: bigint;
+  }): TransactionData {
+    return {
+      to: params.cometAddress,
+      data: encodeFunctionData({
+        abi: COMPOUND_COMET_ABI,
+        functionName: 'withdraw',
+        args: [params.asset, params.amount],
       }),
       value: 0n,
     };


### PR DESCRIPTION
## Summary

Three Phase 3 roadmap items delivered in one PR:

### 1. Compound V3 adapter

New DeFi protocol integration (parallel to Aave V3):

- `POST /v1/transactions/supply-compound` — supply an asset to Compound V3
- `POST /v1/transactions/withdraw-compound` — withdraw (supports `"max"`)
- `TransactionBuilder.buildCompoundSupply()` / `buildCompoundWithdraw()`
- Comet USDC market addresses for Mainnet, Base, Arbitrum, Polygon

### 2. Reputation time-decay (v2.1)

- Recent 30-day transactions carry **2x weight** vs historical
- Same weighting for job completion rate (by `updatedAt`)
- Recovers reputation faster for agents improving, penalizes regressions faster

### 3. Daily reputation cron

- New `packages/backend/src/queues/reputation.queue.ts`
- BullMQ repeatable job runs `updateAllReputationScores()` at **02:00 UTC daily**
- Override schedule via `REPUTATION_CRON_PATTERN` env var
- Graceful shutdown integrated

## Test plan

- [x] Local typecheck passes (all workspaces)
- [ ] CI green (lint, backend, admin, foundry, E2E, preflight)

## Roadmap impact

Marks the following as done in Phase 3:
- DeFi Protocol Expansion — Compound V3 (first protocol)
- Reputation time-decay
- Daily reputation cron