### PR TITLE
feat(mcp): Compound V3 MCP tools + Phase 3 docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TransactionBuilder.buildCompoundSupply()` and `buildCompoundWithdraw()` methods
 - `COMPOUND_COMET_ABI` constant for Comet market contracts
 - Compound V3 USDC market addresses added to `contracts.ts` (Mainnet, Base, Arbitrum, Polygon)
+- **MCP tools `supply_compound` and `withdraw_compound`** exposed in both the standalone mcp-server package and the backend MCP endpoint (13 total tools)
 - **Reputation Scoring v2**: computed from real behavior metrics (tx success rate 40%, job completion rate 30%, volume score 20%, consistency 10%) instead of simple counter
 - `ReputationService.computeReputationScore()`, `refreshReputation()`, `updateAllReputationScores()`
 - Admin endpoints: `POST /admin/reputation/recompute` (all or single agent), `GET /admin/reputation/:agentId` (shows persisted vs computed drift)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -165,8 +165,8 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | GET | `/mcp/sse` | Agent (optional) | SSE stream for tool calls |
 | POST | `/mcp/messages?sessionId=` | Session | JSON-RPC message handler |
 
-**Available MCP Tools** (11):
-`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
+**Available MCP Tools** (13):
+`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
 
 ---
 

--- a/docs/project/go-live-status.md
+++ b/docs/project/go-live-status.md
@@ -70,6 +70,25 @@ AgentFi v0.1.0 is publicly available as open-source software under the Apache 2.
 - GitHub release v0.1.0 created with release notes
 - Repository visibility changed to **public**
 
+### Phase 3 Progress (Post Go-Live)
+
+The following Phase 3 items from `VISION.md` have been delivered:
+
+**A2A Economy Primitives:**
+- ✅ A2A Payment Execution v1 — `executeA2APayment()` triggered on Job COMPLETED
+- ✅ Reputation Scoring v2 — weighted calculation from real metrics
+- ✅ Reputation time-decay (v2.1) — recent 30 days carry 2x weight
+- ✅ Daily reputation cron — BullMQ repeatable job (02:00 UTC)
+
+**DeFi Protocol Expansion:**
+- ✅ Compound V3 adapter (Comet USDC market) — supply/withdraw on 4 chains
+
+**Still pending (Phase 3):**
+- A2A Escrow Pattern (v2) — lock reward on create, release on complete
+- Sign/Verify Handshake — requires Turnkey MPC credentials
+- Curve Finance, GMX, ERC-4626 adapters
+- Fastify v4 → v5 migration
+
 ---
 
 ## Current State
@@ -112,11 +131,13 @@ None (all Dependabot PRs resolved).
 
 ### Phase 3: A2A Economy Primitives (see [roadmap](roadmap.md))
 
-1. **A2A Payment Execution** — bind Job reward to execute_transfer on completion
-2. **Sign/Verify Handshake** — Turnkey MPC signing + EIP-1271 verification
-3. **Reputation Scoring v2** — weighted algorithm based on real behavior metrics
-4. **DeFi Protocol Expansion** — Compound V3, Curve, GMX, ERC-4626 vaults
-5. **Fastify v4 to v5** — resolves remaining HIGH vulnerability
+1. ~~**A2A Payment Execution v1**~~ ✅ Done (PR #28)
+2. **A2A Escrow Pattern v2** — lock reward on create, release on complete, refund on cancel
+3. **Sign/Verify Handshake** — Turnkey MPC signing + EIP-1271 verification
+4. ~~**Reputation Scoring v2 + time-decay**~~ ✅ Done (PRs #28, #29)
+5. **DeFi Protocol Expansion** — ✅ Compound V3 done; Curve, GMX, ERC-4626 pending
+6. **Fastify v4 to v5** — resolves remaining HIGH vulnerability
+7. **MCP tools for Compound** — expose supply-compound/withdraw-compound as MCP tools
 
 ### Phase 4: Self-Sustaining Agents (see [roadmap](roadmap.md))
 

--- a/packages/backend/src/api/routes/mcp.ts
+++ b/packages/backend/src/api/routes/mcp.ts
@@ -143,6 +143,28 @@ function buildProxyTools(apiBaseUrl: string, apiKey: string): ToolDef[] {
         call('POST', '/v1/transactions/withdraw', args),
     },
     {
+      name: 'supply_compound',
+      description: 'Supply tokens to Compound V3 (Comet USDC market) to earn yield',
+      inputSchema: z.object({
+        asset: z.string().describe('ERC-20 token address to supply'),
+        amount: z.string().describe('Amount in human-readable decimals'),
+        chainId: z.number().optional().describe('Chain ID (default: 1)'),
+      }),
+      handler: async (args: Record<string, unknown>) =>
+        call('POST', '/v1/transactions/supply-compound', args),
+    },
+    {
+      name: 'withdraw_compound',
+      description: 'Withdraw tokens from Compound V3 position',
+      inputSchema: z.object({
+        asset: z.string().describe('ERC-20 token address to withdraw'),
+        amount: z.string().describe('Amount in decimals, or "max" to withdraw all'),
+        chainId: z.number().optional().describe('Chain ID (default: 1)'),
+      }),
+      handler: async (args: Record<string, unknown>) =>
+        call('POST', '/v1/transactions/withdraw-compound', args),
+    },
+    {
       name: 'get_transaction_status',
       description: 'Get the status of a previously submitted transaction',
       inputSchema: z.object({

--- a/packages/mcp-server/src/tools/defi.ts
+++ b/packages/mcp-server/src/tools/defi.ts
@@ -107,6 +107,69 @@ export const defiTools = [
   },
 
   {
+    name: 'supply_compound',
+    description:
+      'Supplies an asset to Compound V3 (Comet USDC market) to earn yield. ' +
+      'Each Compound V3 market is single-asset; the USDC market accepts USDC as the base asset ' +
+      'plus whitelisted collateral (e.g. WETH, WBTC). Available on Mainnet, Base, Arbitrum, Polygon.',
+    inputSchema: z.object({
+      asset: z
+        .string()
+        .describe('ERC-20 token address to supply. Use USDC for the base asset, or a supported collateral.'),
+      amount: z.string().describe('Amount to supply in human-readable units.'),
+      chain_id: z.number().default(1).describe('Chain ID. Default: 1 (Ethereum mainnet).'),
+    }),
+    handler: async (input: { asset: string; amount: string; chain_id: number }) => {
+      const asset = resolveAssetToken(input.asset, input.chain_id);
+
+      const result = await api.post<{ transactionId: string; status: string }>(
+        '/v1/transactions/supply-compound',
+        {
+          asset,
+          amount: input.amount,
+          chainId: input.chain_id,
+        },
+      );
+
+      return {
+        transactionId: result.transactionId,
+        status: result.status,
+        next: 'Call get_transaction_status to confirm. Your supplied balance accrues interest in the Comet market.',
+      };
+    },
+  },
+
+  {
+    name: 'withdraw_compound',
+    description:
+      'Withdraws a previously supplied asset from Compound V3 (Comet USDC market). ' +
+      'Pass "max" as the amount to withdraw your entire balance.',
+    inputSchema: z.object({
+      asset: z.string().describe('ERC-20 token address to withdraw.'),
+      amount: z.string().describe('Amount to withdraw. Use "max" to withdraw entire balance.'),
+      chain_id: z.number().default(1).describe('Chain ID. Default: 1 (Ethereum mainnet).'),
+    }),
+    handler: async (input: { asset: string; amount: string; chain_id: number }) => {
+      const asset = resolveAssetToken(input.asset, input.chain_id);
+
+      const result = await api.post<{ transactionId: string; status: string }>(
+        '/v1/transactions/withdraw-compound',
+        {
+          asset,
+          amount: input.amount,
+          chainId: input.chain_id,
+        },
+      );
+
+      return {
+        transactionId: result.transactionId,
+        status: result.status,
+        next: 'Call get_transaction_status to track confirmation.',
+      };
+    },
+  },
+
+  {
     name: 'get_defi_rates',
     description:
       'Returns current supply and borrow APY rates for major assets on Aave V3. ' +


### PR DESCRIPTION
## Summary

Exposes the newly added Compound V3 routes (from #29) as MCP tools so agents can call them directly, and updates docs to track Phase 3 progress.

### Changes

- `supply_compound` and `withdraw_compound` added to `packages/mcp-server/src/tools/defi.ts` (standalone npm package)
- Same tools added to `packages/backend/src/api/routes/mcp.ts` (backend MCP proxy)
- `docs/api-reference.md` updated: 13 total MCP tools (was 11)
- `docs/project/go-live-status.md` updated with Phase 3 progress tracking
- `CHANGELOG.md` updated

### Test plan

- [x] Local typecheck passes (all 3 workspaces)
- [ ] CI green