### PR TITLE
feat(phase3): ERC-4626 tokenized vault adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ERC-4626 vault adapter**: generic tokenized vault support — any compliant vault (Yearn, Morpho, Beefy, Gearbox, etc.) works without pre-registration
+- `POST /v1/transactions/deposit-erc4626` and `POST /v1/transactions/withdraw-erc4626`
+- `TransactionBuilder.buildErc4626Deposit()` and `buildErc4626Withdraw()` methods
+- `ERC4626_VAULT_ABI` constant (deposit, withdraw, redeem, asset)
+- MCP tools `deposit_erc4626` and `withdraw_erc4626` in mcp-server + backend proxy (15 total tools)
 - **Reputation Scoring v2.1 (time-decay)**: recent 30-day transactions and job outcomes now carry 2x weight vs historical events
 - **Daily Reputation Cron**: BullMQ repeatable job recomputes all active agents' scores daily at 02:00 UTC (override via `REPUTATION_CRON_PATTERN`)
 - `packages/backend/src/queues/reputation.queue.ts` — new queue, worker, and `scheduleReputationUpdate()`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -76,6 +76,8 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 | POST | `/v1/transactions/withdraw` | Agent | Withdraw from Aave V3 |
 | POST | `/v1/transactions/supply-compound` | Agent | Supply to Compound V3 (Comet USDC market) |
 | POST | `/v1/transactions/withdraw-compound` | Agent | Withdraw from Compound V3 |
+| POST | `/v1/transactions/deposit-erc4626` | Agent | Deposit into any ERC-4626 vault (Yearn, Morpho, Beefy, etc.) |
+| POST | `/v1/transactions/withdraw-erc4626` | Agent | Withdraw from any ERC-4626 vault |
 | POST | `/v1/transactions/batch` | Agent | Multi-call batch (max 20 actions) |
 | GET | `/v1/transactions/:id` | Agent (owner) | Transaction status |
 | GET | `/v1/transactions` | Agent | Paginated history |
@@ -165,8 +167,8 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | GET | `/mcp/sse` | Agent (optional) | SSE stream for tool calls |
 | POST | `/mcp/messages?sessionId=` | Session | JSON-RPC message handler |
 
-**Available MCP Tools** (13):
-`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
+**Available MCP Tools** (15):
+`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `deposit_erc4626`, `withdraw_erc4626`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
 
 ---
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -76,9 +76,9 @@ These items bridge the gap between the current product (agent-to-DeFi) and the v
 
 - **DeFi Protocol Expansion:**
   - [x] Compound V3 (supply/withdraw) — Mainnet, Base, Arbitrum, Polygon
+  - [x] ERC-4626 vault standard (generic yield — any compliant vault works)
   - [ ] Curve Finance (stablecoin swaps)
   - [ ] GMX / Perp DEXes (for advanced agents)
-  - [ ] ERC-4626 vault standard (generic yield)
   - More earning paths = closer to self-sustaining agents
 
 - **Fastify v4 to v5 Migration:**

--- a/packages/backend/src/api/routes/mcp.ts
+++ b/packages/backend/src/api/routes/mcp.ts
@@ -165,6 +165,30 @@ function buildProxyTools(apiBaseUrl: string, apiKey: string): ToolDef[] {
         call('POST', '/v1/transactions/withdraw-compound', args),
     },
     {
+      name: 'deposit_erc4626',
+      description: 'Deposit into any ERC-4626 compliant vault (Yearn, Morpho, Beefy, etc.)',
+      inputSchema: z.object({
+        vault: z.string().describe('ERC-4626 vault contract address'),
+        asset: z.string().describe('Underlying ERC-20 token address'),
+        amount: z.string().describe('Amount in human-readable decimals'),
+        chainId: z.number().optional().describe('Chain ID (default: 1)'),
+      }),
+      handler: async (args: Record<string, unknown>) =>
+        call('POST', '/v1/transactions/deposit-erc4626', args),
+    },
+    {
+      name: 'withdraw_erc4626',
+      description: 'Withdraw from any ERC-4626 compliant vault',
+      inputSchema: z.object({
+        vault: z.string().describe('ERC-4626 vault contract address'),
+        asset: z.string().describe('Underlying ERC-20 token address'),
+        amount: z.string().describe('Amount in decimals, or "max" to withdraw all'),
+        chainId: z.number().optional().describe('Chain ID (default: 1)'),
+      }),
+      handler: async (args: Record<string, unknown>) =>
+        call('POST', '/v1/transactions/withdraw-erc4626', args),
+    },
+    {
       name: 'get_transaction_status',
       description: 'Get the status of a previously submitted transaction',
       inputSchema: z.object({

--- a/packages/backend/src/api/routes/transactions.ts
+++ b/packages/backend/src/api/routes/transactions.ts
@@ -172,6 +172,22 @@ const withdrawSchema = z.object({
   idempotencyKey: z.string().optional(),
 });
 
+const erc4626DepositSchema = z.object({
+  vault: z.string(), // vault contract address
+  asset: z.string(), // underlying token address (for decimals lookup + USD pricing)
+  amount: z.string(),
+  chainId: z.number().default(1),
+  idempotencyKey: z.string().optional(),
+});
+
+const erc4626WithdrawSchema = z.object({
+  vault: z.string(),
+  asset: z.string(),
+  amount: z.string(), // "max" or decimal amount
+  chainId: z.number().default(1),
+  idempotencyKey: z.string().optional(),
+});
+
 export async function transactionRoutes(fastify: FastifyInstance) {
   /**
    * POST /v1/transactions/simulate — simulate without submitting.
@@ -1039,6 +1055,239 @@ export async function transactionRoutes(fastify: FastifyInstance) {
         agentName: agent.name,
         transactionId: tx.id,
         message: `Compound withdraw (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
+      });
+    }
+
+    return reply.code(202).send({ transactionId: tx.id, status: tx.status });
+  });
+
+  /**
+   * POST /v1/transactions/deposit-erc4626
+   * Deposits an asset into any ERC-4626 compliant vault.
+   * Vault address is supplied by the caller (not from config) so any
+   * compliant vault (Yearn, Morpho, Beefy, etc.) can be used.
+   */
+  fastify.post('/v1/transactions/deposit-erc4626', async (request, reply) => {
+    const body = erc4626DepositSchema.parse(request.body);
+    const agent = await getAgent(request.agentId);
+    if (!ensureChainAllowed(agent, body.chainId, reply)) return;
+
+    if (body.idempotencyKey) {
+      const idempotent = await getIdempotentTransaction(request.agentId, body.idempotencyKey);
+      if (idempotent.existing) return idempotent.existing;
+      if (idempotent.conflictWithAnotherAgent) {
+        return reply.code(409).send({ error: 'idempotencyKey is already in use by another agent' });
+      }
+    }
+
+    const withinLimit = await feeService.checkTxLimit(request.agentId, request.agentTier);
+    if (!withinLimit) {
+      return reply.code(429).send({ error: 'Monthly transaction limit reached' });
+    }
+
+    const decimals = await getTokenDecimals(body.asset, body.chainId);
+    const amountWei = parseUnits(body.amount, decimals);
+
+    const depositTx = builder.buildErc4626Deposit({
+      vaultAddress: getAddress(body.vault),
+      assetAmount: amountWei,
+      receiver: getAddress(agent.safeAddress),
+    });
+
+    const lastTxTimestamp = await getLatestAgentTxTimestamp(request.agentId);
+    const valueUsd = await tokenAmountToUsd(amountWei, body.asset, decimals, body.chainId);
+    const policyResult = await policyService.validateTransaction({
+      agentId: request.agentId,
+      targetContract: depositTx.to,
+      tokenAddress: getAddress(body.asset),
+      valueEth: '0',
+      valueUsd,
+      ...(lastTxTimestamp !== undefined ? { lastTxTimestamp } : {}),
+    });
+    if (!policyResult.allowed) {
+      return reply.code(403).send({ error: policyResult.reason });
+    }
+
+    const sim = await simulator.simulate({
+      chainId: body.chainId,
+      from: getAddress(agent.safeAddress),
+      to: depositTx.to,
+      data: depositTx.data,
+      value: depositTx.value,
+    });
+    if (!sim.success) {
+      return reply.code(422).send({ error: `Simulation failed: ${sim.error}` });
+    }
+
+    const feeCalc = feeService.calculateFee({ grossAmountWei: amountWei, tier: request.agentTier });
+
+    const tx = await db.transaction.create({
+      data: {
+        agentId: request.agentId,
+        idempotencyKey: body.idempotencyKey ?? null,
+        chainId: body.chainId,
+        status: policyResult.requiresApproval ? 'PENDING_APPROVAL' : 'QUEUED',
+        type: 'DEPOSIT',
+        fromToken: body.asset,
+        amountIn: body.amount,
+        simulation: sim as any,
+        metadata: {
+          protocol: 'erc4626',
+          vaultAddress: body.vault,
+          queuePayload: {
+            to: depositTx.to,
+            data: depositTx.data,
+            value: depositTx.value.toString(),
+            feeAmountWei: feeCalc.feeAmountWei.toString(),
+            feeBps: feeCalc.feeBps,
+            routedViaExecutor: false,
+          },
+        },
+      },
+    });
+
+    if (!policyResult.requiresApproval) {
+      await transactionQueue.add('erc4626-deposit', {
+        transactionId: tx.id,
+        chainId: body.chainId,
+        walletId: agent.walletId,
+        from: getAddress(agent.safeAddress),
+        to: depositTx.to,
+        data: depositTx.data,
+        value: depositTx.value.toString(),
+        agentId: request.agentId,
+        tier: request.agentTier,
+        feeAmountWei: feeCalc.feeAmountWei.toString(),
+        feeUsd: '0',
+        feeBps: feeCalc.feeBps,
+        routedViaExecutor: false,
+      });
+    } else {
+      await notificationService.notify({
+        type: 'PENDING_APPROVAL',
+        agentId: request.agentId,
+        agentName: agent.name,
+        transactionId: tx.id,
+        message: `ERC-4626 deposit (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
+      });
+    }
+
+    return reply.code(202).send({ transactionId: tx.id, status: tx.status });
+  });
+
+  /**
+   * POST /v1/transactions/withdraw-erc4626
+   * Withdraws assets from any ERC-4626 compliant vault.
+   */
+  fastify.post('/v1/transactions/withdraw-erc4626', async (request, reply) => {
+    const body = erc4626WithdrawSchema.parse(request.body);
+    const agent = await getAgent(request.agentId);
+    if (!ensureChainAllowed(agent, body.chainId, reply)) return;
+
+    if (body.idempotencyKey) {
+      const idempotent = await getIdempotentTransaction(request.agentId, body.idempotencyKey);
+      if (idempotent.existing) return idempotent.existing;
+      if (idempotent.conflictWithAnotherAgent) {
+        return reply.code(409).send({ error: 'idempotencyKey is already in use by another agent' });
+      }
+    }
+
+    const withinLimit = await feeService.checkTxLimit(request.agentId, request.agentTier);
+    if (!withinLimit) {
+      return reply.code(429).send({ error: 'Monthly transaction limit reached' });
+    }
+
+    const decimals = await getTokenDecimals(body.asset, body.chainId);
+    const amountWei = body.amount === 'max' ? maxUint256 : parseUnits(body.amount, decimals);
+
+    const withdrawTx = builder.buildErc4626Withdraw({
+      vaultAddress: getAddress(body.vault),
+      assetAmount: amountWei,
+      receiver: getAddress(agent.safeAddress),
+      owner: getAddress(agent.safeAddress),
+    });
+
+    const lastTxTimestamp = await getLatestAgentTxTimestamp(request.agentId);
+    const valueUsd =
+      body.amount === 'max'
+        ? '0'
+        : await tokenAmountToUsd(amountWei, body.asset, decimals, body.chainId);
+    const policyResult = await policyService.validateTransaction({
+      agentId: request.agentId,
+      targetContract: withdrawTx.to,
+      tokenAddress: getAddress(body.asset),
+      valueEth: '0',
+      valueUsd,
+      ...(lastTxTimestamp !== undefined ? { lastTxTimestamp } : {}),
+    });
+    if (!policyResult.allowed) {
+      return reply.code(403).send({ error: policyResult.reason });
+    }
+
+    const sim = await simulator.simulate({
+      chainId: body.chainId,
+      from: getAddress(agent.safeAddress),
+      to: withdrawTx.to,
+      data: withdrawTx.data,
+      value: withdrawTx.value,
+    });
+    if (!sim.success) {
+      return reply.code(422).send({ error: `Simulation failed: ${sim.error}` });
+    }
+
+    const feeCalc = feeService.calculateFee({
+      grossAmountWei: 0n,
+      tier: request.agentTier,
+    });
+
+    const tx = await db.transaction.create({
+      data: {
+        agentId: request.agentId,
+        idempotencyKey: body.idempotencyKey ?? null,
+        chainId: body.chainId,
+        status: policyResult.requiresApproval ? 'PENDING_APPROVAL' : 'QUEUED',
+        type: 'WITHDRAW',
+        fromToken: body.asset,
+        amountIn: body.amount,
+        simulation: sim as any,
+        metadata: {
+          protocol: 'erc4626',
+          vaultAddress: body.vault,
+          queuePayload: {
+            to: withdrawTx.to,
+            data: withdrawTx.data,
+            value: withdrawTx.value.toString(),
+            feeAmountWei: feeCalc.feeAmountWei.toString(),
+            feeBps: feeCalc.feeBps,
+            routedViaExecutor: false,
+          },
+        },
+      },
+    });
+
+    if (!policyResult.requiresApproval) {
+      await transactionQueue.add('erc4626-withdraw', {
+        transactionId: tx.id,
+        chainId: body.chainId,
+        walletId: agent.walletId,
+        from: getAddress(agent.safeAddress),
+        to: withdrawTx.to,
+        data: withdrawTx.data,
+        value: withdrawTx.value.toString(),
+        agentId: request.agentId,
+        tier: request.agentTier,
+        feeAmountWei: feeCalc.feeAmountWei.toString(),
+        feeUsd: '0',
+        feeBps: feeCalc.feeBps,
+        routedViaExecutor: false,
+      });
+    } else {
+      await notificationService.notify({
+        type: 'PENDING_APPROVAL',
+        agentId: request.agentId,
+        agentName: agent.name,
+        transactionId: tx.id,
+        message: `ERC-4626 withdraw (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
       });
     }
 

--- a/packages/backend/src/services/transaction/builder.service.ts
+++ b/packages/backend/src/services/transaction/builder.service.ts
@@ -79,7 +79,7 @@ const AAVE_POOL_ABI = [
   },
 ] as const;
 
-// Compound V3 (Comet) ABI — single-asset market contracts.
+// Compound V3 (Comet) ABI ï¿½ single-asset market contracts.
 // supply(asset, amount): supplies collateral OR base asset to the Comet market.
 // withdraw(asset, amount): withdraws base asset (or collateral) back to msg.sender.
 const COMPOUND_COMET_ABI = [
@@ -102,6 +102,50 @@ const COMPOUND_COMET_ABI = [
       { name: 'amount', type: 'uint256' },
     ],
     outputs: [],
+  },
+] as const;
+
+// ERC-4626 Tokenized Vault Standard ABI â€” any compliant vault (Yearn, Morpho,
+// Beefy, ERC4626-wrapped strategies). Four functions cover the full lifecycle.
+const ERC4626_VAULT_ABI = [
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+    ],
+    outputs: [{ name: 'shares', type: 'uint256' }],
+  },
+  {
+    name: 'withdraw',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'assets', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+      { name: 'owner', type: 'address' },
+    ],
+    outputs: [{ name: 'shares', type: 'uint256' }],
+  },
+  {
+    name: 'redeem',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'shares', type: 'uint256' },
+      { name: 'receiver', type: 'address' },
+      { name: 'owner', type: 'address' },
+    ],
+    outputs: [{ name: 'assets', type: 'uint256' }],
+  },
+  {
+    name: 'asset',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address' }],
   },
 ] as const;
 
@@ -275,6 +319,47 @@ export class TransactionBuilder {
         abi: COMPOUND_COMET_ABI,
         functionName: 'withdraw',
         args: [params.asset, params.amount],
+      }),
+      value: 0n,
+    };
+  }
+
+  /**
+   * Builds an ERC-4626 vault deposit.
+   * The vault internally converts assets to shares; receiver gets the shares.
+   */
+  buildErc4626Deposit(params: {
+    vaultAddress: Address;
+    assetAmount: bigint;
+    receiver: Address;
+  }): TransactionData {
+    return {
+      to: params.vaultAddress,
+      data: encodeFunctionData({
+        abi: ERC4626_VAULT_ABI,
+        functionName: 'deposit',
+        args: [params.assetAmount, params.receiver],
+      }),
+      value: 0n,
+    };
+  }
+
+  /**
+   * Builds an ERC-4626 vault withdraw (assets-denominated).
+   * Use `redeem` if you want to burn a specific share amount instead.
+   */
+  buildErc4626Withdraw(params: {
+    vaultAddress: Address;
+    assetAmount: bigint;
+    receiver: Address;
+    owner: Address;
+  }): TransactionData {
+    return {
+      to: params.vaultAddress,
+      data: encodeFunctionData({
+        abi: ERC4626_VAULT_ABI,
+        functionName: 'withdraw',
+        args: [params.assetAmount, params.receiver, params.owner],
       }),
       value: 0n,
     };

--- a/packages/mcp-server/src/tools/defi.ts
+++ b/packages/mcp-server/src/tools/defi.ts
@@ -170,6 +170,81 @@ export const defiTools = [
   },
 
   {
+    name: 'deposit_erc4626',
+    description:
+      'Deposits an asset into any ERC-4626 compliant vault (Yearn, Morpho, Beefy, etc.). ' +
+      'The vault address is supplied by the caller — no pre-registration needed. ' +
+      'Useful for any yield strategy that follows the tokenized-vault standard.',
+    inputSchema: z.object({
+      vault: z.string().describe('ERC-4626 vault contract address to deposit into.'),
+      asset: z.string().describe('Underlying ERC-20 token address (for decimals + USD pricing).'),
+      amount: z.string().describe('Amount of underlying asset to deposit, in human-readable units.'),
+      chain_id: z.number().default(1).describe('Chain ID. Default: 1 (Ethereum mainnet).'),
+    }),
+    handler: async (input: {
+      vault: string;
+      asset: string;
+      amount: string;
+      chain_id: number;
+    }) => {
+      const asset = resolveAssetToken(input.asset, input.chain_id);
+
+      const result = await api.post<{ transactionId: string; status: string }>(
+        '/v1/transactions/deposit-erc4626',
+        {
+          vault: input.vault,
+          asset,
+          amount: input.amount,
+          chainId: input.chain_id,
+        },
+      );
+
+      return {
+        transactionId: result.transactionId,
+        status: result.status,
+        next: 'Call get_transaction_status to confirm. You will receive vault shares proportional to your deposit.',
+      };
+    },
+  },
+
+  {
+    name: 'withdraw_erc4626',
+    description:
+      'Withdraws assets from any ERC-4626 compliant vault. ' +
+      'Use "max" to attempt a full withdrawal (vault may still limit to available liquidity).',
+    inputSchema: z.object({
+      vault: z.string().describe('ERC-4626 vault contract address to withdraw from.'),
+      asset: z.string().describe('Underlying ERC-20 token address.'),
+      amount: z.string().describe('Amount to withdraw. Use "max" for the full balance.'),
+      chain_id: z.number().default(1).describe('Chain ID. Default: 1 (Ethereum mainnet).'),
+    }),
+    handler: async (input: {
+      vault: string;
+      asset: string;
+      amount: string;
+      chain_id: number;
+    }) => {
+      const asset = resolveAssetToken(input.asset, input.chain_id);
+
+      const result = await api.post<{ transactionId: string; status: string }>(
+        '/v1/transactions/withdraw-erc4626',
+        {
+          vault: input.vault,
+          asset,
+          amount: input.amount,
+          chainId: input.chain_id,
+        },
+      );
+
+      return {
+        transactionId: result.transactionId,
+        status: result.status,
+        next: 'Call get_transaction_status to track confirmation.',
+      };
+    },
+  },
+
+  {
     name: 'get_defi_rates',
     description:
       'Returns current supply and borrow APY rates for major assets on Aave V3. ' +


### PR DESCRIPTION
## Summary

Generic ERC-4626 adapter — any compliant vault (Yearn, Morpho, Beefy, Gearbox, etc.) works without pre-registration. The vault address is caller-supplied at request time.

### Why ERC-4626

ERC-4626 is the de-facto tokenized vault standard. By supporting the standard interface, AgentFi gains access to the entire ecosystem of yield vaults in a single adapter. No per-protocol implementation needed.

### Changes

**Builder** (`builder.service.ts`):
- `ERC4626_VAULT_ABI` — 4 functions (deposit, withdraw, redeem, asset)
- `buildErc4626Deposit()` and `buildErc4626Withdraw()` methods

**Routes** (`transactions.ts`):
- `POST /v1/transactions/deposit-erc4626` — `{ vault, asset, amount, chainId }`
- `POST /v1/transactions/withdraw-erc4626` — supports `"max"` amount
- Full pipeline reused: policy + simulation + fee + queue
- Metadata includes `protocol: 'erc4626'` and `vaultAddress` for audit

**MCP tools:**
- `deposit_erc4626` and `withdraw_erc4626` in standalone mcp-server package
- Same tools in backend MCP proxy
- 15 total MCP tools (was 13)

**Docs:**
- API reference updated
- Roadmap: marked Phase 3 ERC-4626 as done
- CHANGELOG updated

## Test plan

- [x] Local typecheck passes (all 3 workspaces)
- [ ] CI green