### PR TITLE
feat(phase4): Agent P&L Dashboard v1 — breakeven detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent P&L Dashboard (Phase 4)**: per-agent profit & loss computed from real DB data
+- New `PnLService` in `packages/backend/src/services/billing/pnl.service.ts`
+- `GET /v1/agents/me/pnl` — agent-facing P&L with earnings, costs, breakeven status
+- `GET /admin/agents/:id/pnl` — admin version for any agent
+- Both accept optional `?since=<ISO8601>` query param
+- Earnings: A2A job rewards received as provider (COMPLETED jobs)
+- Costs: protocol fees paid + A2A rewards paid as requester
+- Directly serves VISION.md thesis: "the moment an agent's earnings exceed its costs..."
 - **A2A Escrow v2**: reward funds are reserved at job creation time and released on terminal state
 - New `EscrowService`: `reserveJobEscrow()`, `releaseJobEscrow()`, `markEscrowReleased()`
 - Migration 0005: adds `reservedAmount`, `reservedToken`, `reservedChainId`, `reservedAt`, `reservationStatus` to Job

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,6 +35,7 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 | GET | `/v1/agents/:id/manifest` | Public | Service manifest for A2A discovery |
 | PATCH | `/v1/agents/me/manifest` | Agent | Update own service manifest |
 | GET | `/v1/agents/:id/trust-report` | Public | Reputation score, A2A tx count |
+| GET | `/v1/agents/me/pnl` | Agent | Profit & loss breakdown (earnings, costs, breakeven) |
 | POST | `/v1/agents/me/sign-handshake` | Agent | **501** - Not implemented |
 | POST | `/v1/agents/verify-handshake` | Public | **501** - Not implemented |
 | DELETE | `/v1/agents/:id` | Agent (owner) | Soft deactivate + emergency pause |
@@ -157,6 +158,7 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | GET | `/admin/revenue` | Revenue breakdown by tier |
 | POST | `/admin/reputation/recompute` | Recompute reputation (all or single agent via body) |
 | GET | `/admin/reputation/:agentId` | Reputation detail with persisted vs computed drift |
+| GET | `/admin/agents/:id/pnl` | Profit & loss breakdown for any agent |
 
 ---
 

--- a/docs/project/go-live-status.md
+++ b/docs/project/go-live-status.md
@@ -85,11 +85,20 @@ The following Phase 3 items from `VISION.md` have been delivered:
 - ✅ ERC-4626 vault adapter (generic — any compliant vault works)
 - ✅ A2A Escrow v2 — reward locked at job creation, released on terminal state
 
+**Phase 4 Progress (post go-live):**
+- ✅ Agent P&L Dashboard v1 — breakeven detection per agent
+
 **Still pending (Phase 3):**
 - Sign/Verify Handshake — requires Turnkey MPC credentials
 - Curve Finance, GMX adapters
 - Fastify v4 → v5 migration
 - A2A Escrow v3 (on-chain escrow contract)
+
+**Still pending (Phase 4):**
+- P&L v2 — gas costs + realized yield
+- Agent self-funding (agent provisions own sub-wallet from earnings)
+- Persistent identity (ENS / DID)
+- Revenue sharing for self-hosted operators
 
 ---
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -96,9 +96,14 @@ These items bridge the gap between the current product (agent-to-DeFi) and the v
 ## Phase 4: Self-Sustaining Agents
 *The transition from tool to participant (see VISION.md "Self-sustaining agents").*
 
-- **Agent P&L Dashboard:**
-  - Track earnings (yield, A2A rewards) vs costs (gas, fees) per agent
-  - Surface the moment an agent's earnings exceed its costs
+- [x] **Agent P&L Dashboard v1** (April 2026):
+  - [x] `GET /v1/agents/me/pnl` and `GET /admin/agents/:id/pnl` endpoints
+  - [x] Earnings: A2A job rewards received as provider
+  - [x] Costs: protocol fees paid + A2A rewards paid as requester
+  - [x] `breakEven` and `profitable` flags per agent
+  - [x] Optional `?since=<ISO>` period filter
+  - [ ] Gas costs (v2 — requires on-chain gasPrice tracking)
+  - [ ] Realized yield from DEPOSIT positions (v2 — requires on-chain reads)
 
 - **Agent Self-Funding:**
   - Agent provisions own sub-wallet from earnings

--- a/packages/backend/src/api/routes/admin.ts
+++ b/packages/backend/src/api/routes/admin.ts
@@ -13,8 +13,10 @@ import { getAddress } from 'viem';
 import { logger } from '../middleware/logger.js';
 import { transactionQueue } from '../../queues/transaction.queue.js';
 import { ReputationService } from '../../services/policy/reputation.service.js';
+import { PnLService } from '../../services/billing/pnl.service.js';
 
 const reputationService = new ReputationService();
+const pnlService = new PnLService();
 const ADMIN_SECRET = process.env['ADMIN_SECRET'] ?? '';
 const ADMIN_ALLOW_REMOTE = process.env['ADMIN_ALLOW_REMOTE'] === 'true';
 
@@ -489,6 +491,38 @@ export async function adminRoutes(fastify: FastifyInstance) {
         persistedScore: agent.reputationScore,
         drift: freshScore - agent.reputationScore,
       };
+    },
+  );
+
+  /**
+   * GET /admin/agents/:id/pnl
+   * Profit & loss breakdown for any agent (admin auth).
+   * Query param: since (optional ISO8601, defaults to agent.createdAt)
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/admin/agents/:id/pnl',
+    async (request, reply) => {
+      if (!requireAdmin(request, reply)) return;
+
+      const query = request.query as { since?: string };
+      const since = query.since ? new Date(query.since) : undefined;
+      if (since && Number.isNaN(since.getTime())) {
+        return reply.code(400).send({ error: 'Invalid `since` parameter (must be ISO8601)' });
+      }
+
+      try {
+        return await pnlService.computeAgentPnL({
+          agentId: request.params.id,
+          ...(since ? { since } : {}),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('not found')) {
+          return reply.code(404).send({ error: msg });
+        }
+        logger.error({ err, agentId: request.params.id }, 'P&L compute failed');
+        return reply.code(500).send({ error: 'Failed to compute P&L' });
+      }
     },
   );
 }

--- a/packages/backend/src/api/routes/agents.ts
+++ b/packages/backend/src/api/routes/agents.ts
@@ -6,11 +6,13 @@ import { SafeService } from '../../services/wallet/safe.service.js';
 import { generateApiKey } from '../middleware/auth.js';
 import { PolicyService } from '../../services/policy/policy.service.js';
 import { ReputationService } from '../../services/policy/reputation.service.js';
+import { PnLService } from '../../services/billing/pnl.service.js';
 import { logger } from '../middleware/logger.js';
 const turnkey = new TurnkeyService();
 const safeService = new SafeService();
 const policyService = new PolicyService(db);
 const reputationService = new ReputationService();
+const pnlService = new PnLService();
 
 const createAgentSchema = z.object({
   name: z.string().min(1).max(100),
@@ -365,6 +367,28 @@ export async function agentRoutes(fastify: FastifyInstance) {
       details: 'A2A handshake verification requires EIP-1271 or ECDSA recovery. See: https://eips.ethereum.org/EIPS/eip-1271',
     });
   });
+
+  /**
+   * GET /v1/agents/me/pnl — profit & loss breakdown for the current agent.
+   *
+   * Directly serves the VISION.md thesis: "the moment an agent's earnings
+   * exceed its costs, it has crossed a line that no AI system has crossed before."
+   *
+   * Query param:
+   *   - since: optional ISO8601 period start (defaults to agent.createdAt)
+   */
+  fastify.get('/v1/agents/me/pnl', async (request, reply) => {
+    const query = request.query as { since?: string };
+    const since = query.since ? new Date(query.since) : undefined;
+    if (since && Number.isNaN(since.getTime())) {
+      return reply.code(400).send({ error: 'Invalid `since` parameter (must be ISO8601)' });
+    }
+    return pnlService.computeAgentPnL({
+      agentId: request.agentId,
+      ...(since ? { since } : {}),
+    });
+  });
+
   /**
    * DELETE /v1/agents/:id — deactivate agent (soft delete).
    */

--- a/packages/backend/src/services/billing/pnl.service.ts
+++ b/packages/backend/src/services/billing/pnl.service.ts
@@ -1,0 +1,199 @@
+/**
+ * PnL Service — computes per-agent profit & loss from existing DB data.
+ *
+ * This endpoint directly serves VISION.md's thesis:
+ *   "The moment an agent's earnings exceed its costs, it has crossed a line
+ *    that no AI system has crossed before."
+ *
+ * Earnings sources (v1):
+ *   - A2A job rewards received (this agent as provider, status=COMPLETED)
+ *
+ * Cost sources (v1):
+ *   - Protocol fees paid (FeeEvent records linked via AgentBilling)
+ *   - A2A job rewards paid out (this agent as requester, status=COMPLETED)
+ *
+ * Deferred to v2:
+ *   - Gas costs (gasPrice not reliably stored at confirmation time)
+ *   - Realized yield from DEPOSIT transactions (needs on-chain reads)
+ *
+ * USD conversion uses the same price oracle as the fee and escrow services.
+ * On oracle failure, individual values are returned as '0' (graceful degradation).
+ */
+
+import { parseEther, parseUnits } from 'viem';
+import { db } from '../../db/client.js';
+import { weiToUsd, tokenAmountToUsd } from '../transaction/price.service.js';
+import { logger } from '../../api/middleware/logger.js';
+
+export interface PnLBreakdown {
+  agentId: string;
+  name: string;
+  periodStart: string;
+  periodEnd: string;
+  earnings: {
+    a2aJobsAsProvider: { count: number; usd: string };
+    totalEarningsUsd: string;
+  };
+  costs: {
+    protocolFees: { count: number; usd: string };
+    a2aJobsAsRequester: { count: number; usd: string };
+    totalCostsUsd: string;
+  };
+  netPnlUsd: string;
+  breakEven: boolean;
+  profitable: boolean;
+  notes: string[];
+}
+
+interface RewardJson {
+  amount?: string;
+  token?: string;
+  chainId?: number;
+}
+
+/**
+ * Convert a reward spec to USD string. Returns '0' on any failure
+ * (unknown token, price oracle error, malformed amount).
+ */
+async function rewardToUsd(reward: RewardJson | null): Promise<string> {
+  if (!reward || !reward.amount) return '0';
+
+  const token = reward.token ?? 'ETH';
+  const chainId = reward.chainId ?? 1;
+  const isEth = token.toUpperCase() === 'ETH';
+
+  try {
+    if (isEth) {
+      const wei = parseEther(reward.amount);
+      return await weiToUsd(wei, chainId);
+    }
+    // Assume 6 decimals (USDC/USDT) as MVP fallback.
+    const units = parseUnits(reward.amount, 6);
+    return await tokenAmountToUsd(units, token, 6, chainId);
+  } catch {
+    return '0';
+  }
+}
+
+export class PnLService {
+  /**
+   * Computes P&L for a single agent.
+   * @param agentId - the agent to analyze
+   * @param since - optional start of the period (defaults to agent.createdAt)
+   */
+  async computeAgentPnL(params: {
+    agentId: string;
+    since?: Date;
+  }): Promise<PnLBreakdown> {
+    const agent = await db.agent.findUnique({
+      where: { id: params.agentId },
+      select: { id: true, name: true, createdAt: true },
+    });
+
+    if (!agent) {
+      throw new Error(`Agent ${params.agentId} not found`);
+    }
+
+    const periodStart = params.since ?? agent.createdAt;
+    const periodEnd = new Date();
+    const notes: string[] = [];
+
+    // --- Earnings: A2A jobs as provider (COMPLETED) ---
+    const jobsAsProvider = await db.job.findMany({
+      where: {
+        providerId: agent.id,
+        status: 'COMPLETED',
+        updatedAt: { gte: periodStart },
+      },
+      select: { reward: true },
+    });
+
+    let earningsUsd = 0;
+    for (const job of jobsAsProvider) {
+      const usd = await rewardToUsd(job.reward as RewardJson | null);
+      earningsUsd += parseFloat(usd);
+    }
+
+    // --- Costs: protocol fees paid ---
+    const feeEvents = await db.feeEvent.findMany({
+      where: {
+        billing: { agentId: agent.id },
+        collectedAt: { gte: periodStart },
+      },
+      select: { feeUsd: true },
+    });
+
+    const protocolFeesUsd = feeEvents.reduce(
+      (acc, fe) => acc + parseFloat(fe.feeUsd || '0'),
+      0,
+    );
+
+    // --- Costs: A2A jobs as requester (COMPLETED) ---
+    const jobsAsRequester = await db.job.findMany({
+      where: {
+        requesterId: agent.id,
+        status: 'COMPLETED',
+        updatedAt: { gte: periodStart },
+      },
+      select: { reward: true },
+    });
+
+    let rewardsPaidUsd = 0;
+    for (const job of jobsAsRequester) {
+      const usd = await rewardToUsd(job.reward as RewardJson | null);
+      rewardsPaidUsd += parseFloat(usd);
+    }
+
+    // Deferred items — surface in notes rather than silently skipping.
+    notes.push(
+      'Gas costs not included in v1 (gasPrice not tracked at confirmation).',
+    );
+    notes.push(
+      'Realized yield from DEPOSIT transactions not included in v1.',
+    );
+
+    const totalEarningsUsd = earningsUsd;
+    const totalCostsUsd = protocolFeesUsd + rewardsPaidUsd;
+    const netPnlUsd = totalEarningsUsd - totalCostsUsd;
+
+    const breakdown: PnLBreakdown = {
+      agentId: agent.id,
+      name: agent.name,
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd.toISOString(),
+      earnings: {
+        a2aJobsAsProvider: {
+          count: jobsAsProvider.length,
+          usd: totalEarningsUsd.toFixed(6),
+        },
+        totalEarningsUsd: totalEarningsUsd.toFixed(6),
+      },
+      costs: {
+        protocolFees: {
+          count: feeEvents.length,
+          usd: protocolFeesUsd.toFixed(6),
+        },
+        a2aJobsAsRequester: {
+          count: jobsAsRequester.length,
+          usd: rewardsPaidUsd.toFixed(6),
+        },
+        totalCostsUsd: totalCostsUsd.toFixed(6),
+      },
+      netPnlUsd: netPnlUsd.toFixed(6),
+      breakEven: netPnlUsd >= 0,
+      profitable: netPnlUsd > 0,
+      notes,
+    };
+
+    logger.info(
+      {
+        agentId: agent.id,
+        netPnlUsd: breakdown.netPnlUsd,
+        profitable: breakdown.profitable,
+      },
+      'Agent P&L computed',
+    );
+
+    return breakdown;
+  }
+}


### PR DESCRIPTION
## Summary

Opens Phase 4 of the roadmap. This is the endpoint that directly serves VISION.md's central thesis:

> *"The moment an agent's earnings exceed its costs, it has crossed a line that no AI system has crossed before."*

## What it does

New `PnLService` computes per-agent profit & loss from immutable DB data — no new writes, no caching, always fresh.

**Earnings:**
- A2A job rewards received as provider (completed jobs)

**Costs:**
- Protocol fees paid (from FeeEvent records)
- A2A rewards paid out as requester (completed jobs)

**Output:**
- `netPnlUsd`, `breakEven`, `profitable` flags
- Per-category counts and USD values
- `notes` array surfacing deferred items

## New endpoints

- `GET /v1/agents/me/pnl` — agent-facing (uses their own API key)
- `GET /admin/agents/:id/pnl` — admin-authed, any agent
- Both accept optional `?since=<ISO8601>` period filter

## Deferred to v2

- Gas costs — `gasPrice` not reliably persisted at confirmation time, would need on-chain receipt reads
- Realized yield from DEPOSIT positions — needs on-chain balance reads

Both are surfaced in the `notes` array so consumers know they're missing.

## Test plan

- [x] Local typecheck passes (all 4 workspaces)
- [ ] CI green