### PR TITLE
feat(phase3): Curve StableSwap adapter + mcp-server v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Curve Finance StableSwap adapter**: `POST /v1/transactions/swap-curve` — token-to-token swaps on any Curve classic pool (3pool, tri-pool, etc.)
+- `TransactionBuilder.buildCurveSwap()` method with `CURVE_STABLESWAP_ABI`
+- MCP tool `swap_curve` in standalone mcp-server package and backend MCP proxy (16 total tools)
+- mcp-server version bumped to `0.2.0` (adds Compound, ERC-4626, and Curve tools since `0.1.0`)
 - **Agent P&L Dashboard (Phase 4)**: per-agent profit & loss computed from real DB data
 - New `PnLService` in `packages/backend/src/services/billing/pnl.service.ts`
 - `GET /v1/agents/me/pnl` — agent-facing P&L with earnings, costs, breakeven status

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -79,6 +79,7 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 | POST | `/v1/transactions/withdraw-compound` | Agent | Withdraw from Compound V3 |
 | POST | `/v1/transactions/deposit-erc4626` | Agent | Deposit into any ERC-4626 vault (Yearn, Morpho, Beefy, etc.) |
 | POST | `/v1/transactions/withdraw-erc4626` | Agent | Withdraw from any ERC-4626 vault |
+| POST | `/v1/transactions/swap-curve` | Agent | Swap on Curve StableSwap pool (stablecoins, low slippage) |
 | POST | `/v1/transactions/batch` | Agent | Multi-call batch (max 20 actions) |
 | GET | `/v1/transactions/:id` | Agent (owner) | Transaction status |
 | GET | `/v1/transactions` | Agent | Paginated history |
@@ -169,8 +170,8 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | GET | `/mcp/sse` | Agent (optional) | SSE stream for tool calls |
 | POST | `/mcp/messages?sessionId=` | Session | JSON-RPC message handler |
 
-**Available MCP Tools** (15):
-`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `deposit_erc4626`, `withdraw_erc4626`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
+**Available MCP Tools** (16):
+`get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `deposit_erc4626`, `withdraw_erc4626`, `swap_curve`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
 
 ---
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -83,7 +83,7 @@ These items bridge the gap between the current product (agent-to-DeFi) and the v
 - **DeFi Protocol Expansion:**
   - [x] Compound V3 (supply/withdraw) — Mainnet, Base, Arbitrum, Polygon
   - [x] ERC-4626 vault standard (generic yield — any compliant vault works)
-  - [ ] Curve Finance (stablecoin swaps)
+  - [x] Curve Finance StableSwap (classic pools — 3pool, tri-pool, etc.)
   - [ ] GMX / Perp DEXes (for advanced agents)
   - More earning paths = closer to self-sustaining agents
 

--- a/packages/backend/src/api/routes/mcp.ts
+++ b/packages/backend/src/api/routes/mcp.ts
@@ -189,6 +189,22 @@ function buildProxyTools(apiBaseUrl: string, apiKey: string): ToolDef[] {
         call('POST', '/v1/transactions/withdraw-erc4626', args),
     },
     {
+      name: 'swap_curve',
+      description: 'Swap between two assets on a Curve StableSwap pool (stablecoins)',
+      inputSchema: z.object({
+        pool: z.string().describe('Curve pool contract address'),
+        fromTokenIndex: z.number().describe('Index of input token in the pool'),
+        toTokenIndex: z.number().describe('Index of output token in the pool'),
+        fromTokenAddress: z.string().describe('ERC-20 address of input token'),
+        toTokenAddress: z.string().describe('ERC-20 address of output token'),
+        amountIn: z.string().describe('Amount of input token in human-readable units'),
+        minAmountOut: z.string().describe('Minimum output amount (slippage protection)'),
+        chainId: z.number().optional().describe('Chain ID (default: 1)'),
+      }),
+      handler: async (args: Record<string, unknown>) =>
+        call('POST', '/v1/transactions/swap-curve', args),
+    },
+    {
       name: 'get_transaction_status',
       description: 'Get the status of a previously submitted transaction',
       inputSchema: z.object({

--- a/packages/backend/src/api/routes/transactions.ts
+++ b/packages/backend/src/api/routes/transactions.ts
@@ -188,6 +188,18 @@ const erc4626WithdrawSchema = z.object({
   idempotencyKey: z.string().optional(),
 });
 
+const swapCurveSchema = z.object({
+  pool: z.string(),                                   // Curve pool address
+  fromTokenIndex: z.number().int().min(0).max(7),     // int128 in pool
+  toTokenIndex: z.number().int().min(0).max(7),
+  fromTokenAddress: z.string(),                       // for decimals + policy
+  toTokenAddress: z.string(),                         // for metadata
+  amountIn: z.string(),
+  minAmountOut: z.string(),
+  chainId: z.number().default(1),
+  idempotencyKey: z.string().optional(),
+});
+
 export async function transactionRoutes(fastify: FastifyInstance) {
   /**
    * POST /v1/transactions/simulate — simulate without submitting.
@@ -1288,6 +1300,138 @@ export async function transactionRoutes(fastify: FastifyInstance) {
         agentName: agent.name,
         transactionId: tx.id,
         message: `ERC-4626 withdraw (${body.amount} ${body.asset.slice(0, 10)}) exceeds auto-approval threshold.`,
+      });
+    }
+
+    return reply.code(202).send({ transactionId: tx.id, status: tx.status });
+  });
+
+  /**
+   * POST /v1/transactions/swap-curve
+   * Swaps between two assets on a Curve StableSwap pool.
+   *
+   * The caller supplies the pool address and token indices. Assumes the
+   * fromToken has already been approved to the pool. If approval is missing,
+   * the simulation step fails with a clear message.
+   */
+  fastify.post('/v1/transactions/swap-curve', async (request, reply) => {
+    const body = swapCurveSchema.parse(request.body);
+    const agent = await getAgent(request.agentId);
+    if (!ensureChainAllowed(agent, body.chainId, reply)) return;
+
+    if (body.idempotencyKey) {
+      const idempotent = await getIdempotentTransaction(request.agentId, body.idempotencyKey);
+      if (idempotent.existing) return idempotent.existing;
+      if (idempotent.conflictWithAnotherAgent) {
+        return reply.code(409).send({ error: 'idempotencyKey is already in use by another agent' });
+      }
+    }
+
+    const withinLimit = await feeService.checkTxLimit(request.agentId, request.agentTier);
+    if (!withinLimit) {
+      return reply.code(429).send({ error: 'Monthly transaction limit reached' });
+    }
+
+    const fromDecimals = await getTokenDecimals(body.fromTokenAddress, body.chainId);
+    const toDecimals = await getTokenDecimals(body.toTokenAddress, body.chainId);
+    const amountInWei = parseUnits(body.amountIn, fromDecimals);
+    const minAmountOutWei = parseUnits(body.minAmountOut, toDecimals);
+
+    const swapTx = builder.buildCurveSwap({
+      poolAddress: getAddress(body.pool),
+      i: BigInt(body.fromTokenIndex),
+      j: BigInt(body.toTokenIndex),
+      amountIn: amountInWei,
+      minAmountOut: minAmountOutWei,
+    });
+
+    const lastTxTimestamp = await getLatestAgentTxTimestamp(request.agentId);
+    const valueUsd = await tokenAmountToUsd(
+      amountInWei,
+      body.fromTokenAddress,
+      fromDecimals,
+      body.chainId,
+    );
+    const policyResult = await policyService.validateTransaction({
+      agentId: request.agentId,
+      targetContract: swapTx.to,
+      tokenAddress: getAddress(body.fromTokenAddress),
+      valueEth: '0',
+      valueUsd,
+      ...(lastTxTimestamp !== undefined ? { lastTxTimestamp } : {}),
+    });
+    if (!policyResult.allowed) {
+      return reply.code(403).send({ error: policyResult.reason });
+    }
+
+    const sim = await simulator.simulate({
+      chainId: body.chainId,
+      from: getAddress(agent.safeAddress),
+      to: swapTx.to,
+      data: swapTx.data,
+      value: swapTx.value,
+    });
+    if (!sim.success) {
+      return reply.code(422).send({
+        error: `Simulation failed: ${sim.error}. Verify pool exists, indices are correct, and fromToken is approved to the pool.`,
+      });
+    }
+
+    const feeCalc = feeService.calculateFee({
+      grossAmountWei: amountInWei,
+      tier: request.agentTier,
+    });
+
+    const tx = await db.transaction.create({
+      data: {
+        agentId: request.agentId,
+        idempotencyKey: body.idempotencyKey ?? null,
+        chainId: body.chainId,
+        status: policyResult.requiresApproval ? 'PENDING_APPROVAL' : 'QUEUED',
+        type: 'SWAP',
+        fromToken: body.fromTokenAddress,
+        toToken: body.toTokenAddress,
+        amountIn: body.amountIn,
+        simulation: sim as any,
+        metadata: {
+          protocol: 'curve',
+          poolAddress: body.pool,
+          tokenIndices: { from: body.fromTokenIndex, to: body.toTokenIndex },
+          queuePayload: {
+            to: swapTx.to,
+            data: swapTx.data,
+            value: swapTx.value.toString(),
+            feeAmountWei: feeCalc.feeAmountWei.toString(),
+            feeBps: feeCalc.feeBps,
+            routedViaExecutor: false,
+          },
+        },
+      },
+    });
+
+    if (!policyResult.requiresApproval) {
+      await transactionQueue.add('curve-swap', {
+        transactionId: tx.id,
+        chainId: body.chainId,
+        walletId: agent.walletId,
+        from: getAddress(agent.safeAddress),
+        to: swapTx.to,
+        data: swapTx.data,
+        value: swapTx.value.toString(),
+        agentId: request.agentId,
+        tier: request.agentTier,
+        feeAmountWei: feeCalc.feeAmountWei.toString(),
+        feeUsd: '0',
+        feeBps: feeCalc.feeBps,
+        routedViaExecutor: false,
+      });
+    } else {
+      await notificationService.notify({
+        type: 'PENDING_APPROVAL',
+        agentId: request.agentId,
+        agentName: agent.name,
+        transactionId: tx.id,
+        message: `Curve swap (${body.amountIn} ${body.fromTokenAddress.slice(0, 10)}) exceeds auto-approval threshold.`,
       });
     }
 

--- a/packages/backend/src/services/transaction/builder.service.ts
+++ b/packages/backend/src/services/transaction/builder.service.ts
@@ -149,6 +149,24 @@ const ERC4626_VAULT_ABI = [
   },
 ] as const;
 
+// Curve StableSwap (classic) ABI — single function for token-to-token swaps
+// within a pool. Works for 3pool, tricrypto, and all classic stable pools.
+// The `i` and `j` params are int128 by Curve convention (always non-negative).
+const CURVE_STABLESWAP_ABI = [
+  {
+    name: 'exchange',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'i', type: 'int128' },
+      { name: 'j', type: 'int128' },
+      { name: 'dx', type: 'uint256' },
+      { name: 'min_dy', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
 // Uniswap V3 SwapRouter02 ABI — exactInputSingle WITHOUT deadline.
 // SwapRouter02 moves deadline to the multicall wrapper level.
 // Deployed at 0x2626664c2603336E57B271c5C0b26F421741e481 on Base/Arbitrum/Polygon.
@@ -362,6 +380,32 @@ export class TransactionBuilder {
         args: [params.assetAmount, params.receiver, params.owner],
       }),
       value: 0n,
+    };
+  }
+
+  /**
+   * Builds a Curve StableSwap exchange transaction.
+   * Works with classic StableSwap pools (3pool, DAI/USDC/USDT, etc.).
+   * The pool address is caller-supplied, allowing any Curve pool to be used.
+   *
+   * Caller must approve the pool to spend `amountIn` of the input token before
+   * calling this. Simulation will fail clearly if approval is missing.
+   */
+  buildCurveSwap(params: {
+    poolAddress: Address;
+    i: bigint; // from token index (int128, non-negative)
+    j: bigint; // to token index
+    amountIn: bigint;
+    minAmountOut: bigint;
+  }): TransactionData {
+    return {
+      to: params.poolAddress,
+      data: encodeFunctionData({
+        abi: CURVE_STABLESWAP_ABI,
+        functionName: 'exchange',
+        args: [params.i, params.j, params.amountIn, params.minAmountOut],
+      }),
+      value: 0n, // Curve pools never receive ETH
     };
   }
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent_fi/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },
   "description": "AgentFi MCP Server — crypto transaction tools for AI agents",
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit",
     "start": "node --import tsx/esm src/index.ts"
   },
-  "keywords": ["mcp", "defi", "ethereum", "ai-agents", "uniswap", "aave"],
+  "keywords": ["mcp", "defi", "ethereum", "ai-agents", "uniswap", "aave", "compound", "curve", "erc4626"],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.22.4",

--- a/packages/mcp-server/src/tools/defi.ts
+++ b/packages/mcp-server/src/tools/defi.ts
@@ -245,6 +245,66 @@ export const defiTools = [
   },
 
   {
+    name: 'swap_curve',
+    description:
+      'Swaps between two assets on a Curve StableSwap pool. Ideal for stablecoin-to-stablecoin ' +
+      'conversions (USDC↔USDT↔DAI) with minimal slippage. The caller must supply the pool address ' +
+      'and the indices of the input/output tokens within that pool. Assumes fromToken has already ' +
+      'been approved to the pool; simulation will fail clearly if approval is missing.',
+    inputSchema: z.object({
+      pool: z.string().describe('Curve pool contract address.'),
+      from_token_index: z
+        .number()
+        .int()
+        .describe('Index (0, 1, 2, ...) of the input token within the pool.'),
+      to_token_index: z
+        .number()
+        .int()
+        .describe('Index of the output token within the pool.'),
+      from_token_address: z.string().describe('ERC-20 address of the input token.'),
+      to_token_address: z.string().describe('ERC-20 address of the output token.'),
+      amount_in: z.string().describe('Amount of input token in human-readable units.'),
+      min_amount_out: z
+        .string()
+        .describe('Minimum acceptable amount of output token (slippage protection).'),
+      chain_id: z.number().default(1).describe('Chain ID. Default: 1 (Ethereum mainnet).'),
+    }),
+    handler: async (input: {
+      pool: string;
+      from_token_index: number;
+      to_token_index: number;
+      from_token_address: string;
+      to_token_address: string;
+      amount_in: string;
+      min_amount_out: string;
+      chain_id: number;
+    }) => {
+      const fromToken = resolveAssetToken(input.from_token_address, input.chain_id);
+      const toToken = resolveAssetToken(input.to_token_address, input.chain_id);
+
+      const result = await api.post<{ transactionId: string; status: string }>(
+        '/v1/transactions/swap-curve',
+        {
+          pool: input.pool,
+          fromTokenIndex: input.from_token_index,
+          toTokenIndex: input.to_token_index,
+          fromTokenAddress: fromToken,
+          toTokenAddress: toToken,
+          amountIn: input.amount_in,
+          minAmountOut: input.min_amount_out,
+          chainId: input.chain_id,
+        },
+      );
+
+      return {
+        transactionId: result.transactionId,
+        status: result.status,
+        next: 'Call get_transaction_status to track confirmation.',
+      };
+    },
+  },
+
+  {
     name: 'get_defi_rates',
     description:
       'Returns current supply and borrow APY rates for major assets on Aave V3. ' +


### PR DESCRIPTION
## Summary

Adds Curve Finance StableSwap adapter for stablecoin swaps — the missing piece for agents doing USDC/USDT/DAI/FRAX routing and rebalancing.

### Changes

**Builder:**
- `CURVE_STABLESWAP_ABI` — `exchange(int128 i, int128 j, uint256 dx, uint256 min_dy)`
- `buildCurveSwap()` method

**Route:**
- `POST /v1/transactions/swap-curve`
- Request: `{ pool, fromTokenIndex, toTokenIndex, fromTokenAddress, toTokenAddress, amountIn, minAmountOut, chainId }`
- User-supplied pool address (no hardcoding)
- Reuses full pipeline: policy + simulation + fee + queue
- `metadata.protocol = 'curve'` + `metadata.poolAddress` + `metadata.tokenIndices`

**MCP tools:**
- `swap_curve` in mcp-server and backend MCP proxy (16 total tools)

**mcp-server version bump: 0.1.0 → 0.2.0**
- Reflects all additions since first publish (Compound, ERC-4626, Curve)

## Design decisions

- **User-supplied pool address** — Curve has hundreds of pools. Agents should pick their route.
- **No auto-approval** — caller approves pool first (same pattern as ERC-4626, Compound)
- **Reuse `TxType.SWAP`** — distinguished via `metadata.protocol`
- **`value: 0n` always** — Curve pools never accept ETH

## Test plan

- [x] Local typecheck passes (all workspaces)
- [ ] CI green

## Out of scope

- Curve CryptoSwap pools (uint256 indices) — future PR
- LP add/remove liquidity — future PR
- Auto-quotes via `get_dy()` — future PR