### PR TITLE
docs: sync all documentation with current code state

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ All project documentation is organized in our **[Documentation Hub](docs/README.
 ## 🚀 Key Features
 
 - **Turnkey MPC Wallets**: Keys are split across shards and never exposed.
-- **Safe Smart Wallets**: Per-agent on-chain policy enforcement (limits, whitelists).
-- **Model Context Protocol (MCP)**: 10+ DeFi tools for direct agent integration.
+- **Safe Smart Wallets**: Per-agent on-chain policy enforcement (limits, whitelists, kill switch).
+- **Model Context Protocol (MCP)**: 26 structured tools for direct agent integration — 15 DeFi operations + 11 A2A collaboration.
+- **DeFi Coverage**: Uniswap V3 + Curve StableSwap (swaps); Aave V3, Compound V3, and any ERC-4626 vault (yield).
+- **Agent-to-Agent Economy**: job queue, atomic payments, DB-level escrow (v2), reputation scoring from real metrics with time-decay.
+- **Agent P&L Dashboard**: per-agent breakeven detection — the moment an agent's earnings exceed its costs.
 - **Cross-Chain Support**: Ethereum, Base, Arbitrum, and Polygon.
 - **Protocol Fee Engine**: Built-in fee collection on-chain via `AgentExecutor`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -138,6 +138,18 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 
 **Job Statuses**: `PENDING` > `ACCEPTED` > `COMPLETED` | `FAILED` | `CANCELLED`
 
+**Escrow (v2)**: When a job is created with a `reward`, the requester's USD equivalent is committed to their daily volume atomically. Fields on the Job model:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reservedAmount` | string | Amount reserved (human-readable units) |
+| `reservedToken` | string | Token symbol or address |
+| `reservedChainId` | number | Chain where funds are reserved |
+| `reservedAt` | datetime | Reservation timestamp |
+| `reservationStatus` | enum | `PENDING` \| `RELEASED` (paid on COMPLETED) \| `CANCELLED` (returned on FAIL/CANCEL) |
+
+When the job transitions to `COMPLETED`, the escrow is marked `RELEASED` and `executeA2APayment()` runs. On `FAILED` or `CANCELLED`, `releaseJobEscrow()` subtracts the reserved USD back from the requester's daily volume.
+
 ---
 
 ## Admin (Operator)
@@ -170,8 +182,10 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 | GET | `/mcp/sse` | Agent (optional) | SSE stream for tool calls |
 | POST | `/mcp/messages?sessionId=` | Session | JSON-RPC message handler |
 
-**Available MCP Tools** (16):
+**Backend MCP Proxy Tools** (16):
 `get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `deposit_erc4626`, `withdraw_erc4626`, `swap_curve`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
+
+> **Note:** The backend's `/mcp/sse` endpoint exposes a **thin 16-tool proxy** for simple HTTP-over-MCP clients. The standalone `@agent_fi/mcp-server` npm package is richer: **26 tools** including A2A collaboration (`search_agents`, `post_job`, `check_inbox`, `pay_agent`, etc.) — see [packages/mcp-server/README.md](../packages/mcp-server/README.md) for the full catalog.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,14 +5,15 @@
 ```
 ┌─────────────────────────────────────────────────┐
 │  LAYER 4 — MCP Server / Agent Interface Layer   │
-│  10 structured tools consumed by LLM agents     │
+│  26 structured tools (15 DeFi + 11 A2A)         │
 │  stdio (local) + SSE (hosted) transports        │
 ├─────────────────────────────────────────────────┤
-│  LAYER 3 — Backend API (Fastify)                │
+│  LAYER 3 — Backend API (Fastify 5)              │
 │  Orchestration, simulation, tx submission       │
+│  A2A Job Queue + Escrow, Reputation, P&L        │
 │  BullMQ workers, Prisma/PostgreSQL, Redis       │
 ├─────────────────────────────────────────────────┤
-│  LAYER 2 — Smart Contracts (Solidity 0.8.24)   │
+│  LAYER 2 — Smart Contracts (Solidity 0.8.24)    │
 │  AgentPolicyModule — per-Safe tx validation     │
 │  AgentExecutor — atomic batch execution         │
 ├─────────────────────────────────────────────────┤
@@ -51,10 +52,19 @@ When routed through `AgentExecutor`, fee is collected on-chain to `OPERATOR_FEE_
 
 | Chain | ID | Supported Protocols |
 |-------|----|---------------------|
-| Ethereum Mainnet | 1 | Uniswap V3, Aave V3 |
-| Base | 8453 | Uniswap V3, Aave V3 |
-| Arbitrum One | 42161 | Uniswap V3, Aave V3 |
-| Polygon | 137 | Uniswap V3, Aave V3 |
+| Ethereum Mainnet | 1 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (any vault) |
+| Base | 8453 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (any vault) |
+| Arbitrum One | 42161 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (any vault) |
+| Polygon | 137 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (any vault) |
+
+## Agent-to-Agent Layer
+
+Built on top of the transaction pipeline:
+
+- **Job Queue** — agents post paid tasks for other agents (`/v1/jobs`)
+- **Escrow v2** — reward committed to requester's DailyVolume at job creation, released on terminal state (migration 0005)
+- **Reputation Scoring v2.1** — weighted score from real metrics (tx success 40%, job completion 30%, volume 20%, consistency 10%) with 2x time-decay on recent 30 days, recomputed daily via BullMQ cron
+- **Agent P&L Dashboard** — `GET /v1/agents/me/pnl` computes `breakEven` and `profitable` flags from earnings (A2A rewards received) vs costs (protocol fees + rewards paid)
 
 ## Deployed Infrastructure
 

--- a/docs/project/go-live-status.md
+++ b/docs/project/go-live-status.md
@@ -76,28 +76,33 @@ The following Phase 3 items from `VISION.md` have been delivered:
 
 **A2A Economy Primitives:**
 - ✅ A2A Payment Execution v1 — `executeA2APayment()` triggered on Job COMPLETED
+- ✅ A2A Escrow v2 — reward committed to DailyVolume at job creation, released on terminal state (migration 0005)
 - ✅ Reputation Scoring v2 — weighted calculation from real metrics
 - ✅ Reputation time-decay (v2.1) — recent 30 days carry 2x weight
 - ✅ Daily reputation cron — BullMQ repeatable job (02:00 UTC)
 
 **DeFi Protocol Expansion:**
 - ✅ Compound V3 adapter (Comet USDC market) — supply/withdraw on 4 chains
-- ✅ ERC-4626 vault adapter (generic — any compliant vault works)
-- ✅ A2A Escrow v2 — reward locked at job creation, released on terminal state
+- ✅ ERC-4626 vault adapter (generic — any compliant vault works: Yearn, Morpho, Beefy, Gearbox)
+- ✅ Curve StableSwap adapter — stablecoin swaps on any classic Curve pool
+
+**Infrastructure:**
+- ✅ Fastify v4 → v5 migration (last HIGH npm vulnerability eliminated)
+- ✅ mcp-server v0.2.0 bump (adds Compound, ERC-4626, Curve tools; 26 total MCP tools)
+- ✅ `packages/mcp-server/RELEASE.md` — publish guide
 
 **Phase 4 Progress (post go-live):**
-- ✅ Agent P&L Dashboard v1 — breakeven detection per agent
+- ✅ Agent P&L Dashboard v1 — breakeven detection per agent (`GET /v1/agents/me/pnl`)
 
 **Still pending (Phase 3):**
 - Sign/Verify Handshake — requires Turnkey MPC credentials
-- Curve Finance, GMX adapters
-- Fastify v4 → v5 migration
-- A2A Escrow v3 (on-chain escrow contract)
+- GMX / Perp DEXes adapter — complex ABI, leverage risk management
+- A2A Escrow v3 — on-chain escrow contract (requires new Safe module deploy)
 
 **Still pending (Phase 4):**
-- P&L v2 — gas costs + realized yield
-- Agent self-funding (agent provisions own sub-wallet from earnings)
-- Persistent identity (ENS / DID)
+- P&L v2 — gas costs + realized yield from DEPOSIT positions
+- Agent self-funding — agent provisions own sub-wallet from earnings
+- Persistent identity — ENS / DID
 - Revenue sharing for self-hosted operators
 
 ---

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,15 +1,16 @@
-# @agentfi/backend
+# @agent_fi/backend
 
-Core API server for AgentFi — handles agent management, transaction execution, policy enforcement, billing, and the BullMQ worker pipeline.
+Core API server for AgentFi — handles agent management, transaction execution, policy enforcement, billing, A2A jobs + escrow, reputation, and the BullMQ worker pipeline.
 
 ## Stack
 
 - **Runtime**: Node.js 20+ (ESM)
-- **Framework**: Fastify 4
+- **Framework**: Fastify 5
 - **Database**: PostgreSQL 16 + Prisma ORM
-- **Queue**: BullMQ + Redis 7
+- **Queue**: BullMQ + Redis 7 (transaction worker + daily reputation cron)
 - **Wallet**: Turnkey MPC + Safe Smart Accounts
 - **Chains**: Ethereum, Base, Arbitrum, Polygon (via Alchemy)
+- **DeFi**: Uniswap V3 + Curve StableSwap (swaps), Aave V3 + Compound V3 + ERC-4626 vaults (yield)
 
 ## Local Development
 
@@ -36,19 +37,23 @@ npm run dev            # starts API on http://localhost:3000
 
 ## API Reference
 
-See [docs/api-reference.md](../../docs/api-reference.md) for the complete endpoint catalog (47 routes).
+See [docs/api-reference.md](../../docs/api-reference.md) for the complete endpoint catalog.
 
 ## Architecture
 
 ```
 src/
   api/
-    routes/       # Fastify route handlers (agents, transactions, wallet, billing, jobs, admin)
-    middleware/    # Auth, rate limiting, x402
-  config/         # Environment validation (Zod)
+    routes/       # Fastify route handlers (agents, transactions, wallet, billing, jobs, admin, mcp, health)
+    middleware/   # Auth, rate limiting, x402
+  config/         # Environment validation (Zod), chains, contracts
   db/
     schema.prisma # Database schema
-    migrations/   # SQL migrations (0001-0004)
-  queues/         # BullMQ workers (transaction pipeline)
-  services/       # Business logic (fee, policy, price, wallet, transaction)
+    migrations/   # SQL migrations (0001-0005)
+  queues/         # BullMQ workers (transaction pipeline + daily reputation cron)
+  services/
+    billing/      # Stripe + PnLService (agent P&L dashboard)
+    policy/       # FeeService, PolicyService, ReputationService, EscrowService
+    transaction/  # Builder, Executor, Simulator, Monitor, Submitter, PriceService
+    wallet/       # Turnkey + Safe wallet provisioning
 ```

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,34 +1,87 @@
-# @agentfi/mcp-server
+# @agent_fi/mcp-server
 
-MCP server that gives AI agents 10 DeFi tools for executing on-chain transactions across Ethereum, Base, Arbitrum, and Polygon.
+MCP server that gives AI agents 26 tools for executing on-chain transactions and participating in the Agent-to-Agent economy across Ethereum, Base, Arbitrum, and Polygon.
 
 Built on the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) standard. Works with Claude, GPT, and any MCP-compatible client.
 
-## Tools
+## Tools (26 total)
+
+### Wallet & Balances
 
 | Tool | Description |
 |------|-------------|
 | `get_wallet_info` | Get agent's Safe wallet address and token balances |
 | `get_token_price` | Fetch current USD price of any token (CoinGecko) |
+
+### Swaps
+
+| Tool | Description |
+|------|-------------|
 | `simulate_swap` | Simulate a token swap before execution (Tenderly) |
 | `execute_swap` | Execute token swap via Uniswap V3 |
+| `swap_curve` | Swap on a Curve StableSwap pool (stablecoins, low slippage) |
+
+### Transfers
+
+| Tool | Description |
+|------|-------------|
+| `transfer_token` | Transfer ETH or ERC-20 tokens |
+
+### Yield — Aave V3
+
+| Tool | Description |
+|------|-------------|
 | `deposit_aave` | Supply assets to Aave V3 to earn yield |
 | `withdraw_aave` | Withdraw assets from Aave V3 |
 | `get_defi_rates` | Fetch current Aave V3 supply/borrow APY rates |
-| `transfer_token` | Transfer ETH or ERC-20 tokens |
+
+### Yield — Compound V3
+
+| Tool | Description |
+|------|-------------|
+| `supply_compound` | Supply assets to Compound V3 (Comet USDC market) |
+| `withdraw_compound` | Withdraw assets from Compound V3 |
+
+### Yield — ERC-4626 (generic)
+
+| Tool | Description |
+|------|-------------|
+| `deposit_erc4626` | Deposit into any ERC-4626 compliant vault (Yearn, Morpho, Beefy, etc.) |
+| `withdraw_erc4626` | Withdraw from any ERC-4626 compliant vault |
+
+### Transaction Status
+
+| Tool | Description |
+|------|-------------|
 | `get_transaction_status` | Poll transaction status (pending/confirmed/failed) |
 | `get_policy` | View agent's operational limits and restrictions |
+
+### Agent-to-Agent (A2A) Collaboration
+
+| Tool | Description |
+|------|-------------|
+| `search_agents` | Discover other agents by name or address |
+| `get_agent_manifest` | Fetch another agent's service manifest |
+| `set_my_manifest` | Publish your own service manifest for discovery |
+| `get_agent_trust_report` | Fetch another agent's reputation metrics |
+| `post_job` | Create a paid service request for another agent |
+| `check_inbox` | Fetch jobs assigned to you (as provider) |
+| `update_job_status` | Accept / complete / fail / cancel a job |
+| `pay_agent` | Pay another agent directly (outside the job queue) |
+| `request_policy_update` | Propose a policy change (operator-approved) |
+| `sign_handshake` | Sign an A2A identity handshake message (501 — v3 roadmap) |
+| `verify_handshake` | Verify a peer's handshake signature (501 — v3 roadmap) |
 
 ## Installation
 
 ```bash
-npm install @agentfi/mcp-server
+npm install @agent_fi/mcp-server
 ```
 
 Or run directly:
 
 ```bash
-AGENTFI_API_KEY=agfi_live_xxx npx @agentfi/mcp-server
+AGENTFI_API_KEY=agfi_live_xxx npx @agent_fi/mcp-server
 ```
 
 ## Configuration
@@ -42,7 +95,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "agentfi": {
       "command": "npx",
-      "args": ["@agentfi/mcp-server"],
+      "args": ["@agent_fi/mcp-server"],
       "env": {
         "AGENTFI_API_KEY": "agfi_live_xxx"
       }
@@ -60,7 +113,7 @@ Add to your `.mcp.json`:
   "mcpServers": {
     "agentfi": {
       "command": "npx",
-      "args": ["@agentfi/mcp-server"],
+      "args": ["@agent_fi/mcp-server"],
       "env": {
         "AGENTFI_API_KEY": "agfi_live_xxx"
       }
@@ -120,8 +173,9 @@ AgentFi Backend API
     |--- Turnkey (MPC wallet signing)
     |--- Safe (smart account execution)
     |--- Tenderly (transaction simulation)
-    |--- Uniswap V3 (swaps)
-    |--- Aave V3 (lending/borrowing)
+    |--- Uniswap V3 / Curve (swaps)
+    |--- Aave V3 / Compound V3 / ERC-4626 (yield)
+    |--- A2A Job Queue + Reputation
     v
 Blockchain (Ethereum, Base, Arbitrum, Polygon)
 ```
@@ -132,6 +186,7 @@ Blockchain (Ethereum, Base, Arbitrum, Polygon)
 - **Policy constraints** enforced on-chain (max value, daily cap, allowed contracts/tokens)
 - **MPC wallets** — private keys never exist in a single location (Turnkey)
 - **Smart accounts** — Safe multisig with policy module guard
+- **A2A escrow** — job rewards are committed at creation time (v2 DB escrow)
 
 ## Example Usage
 
@@ -140,21 +195,22 @@ Once connected via MCP, an AI agent can:
 ```
 Agent: "Check my wallet balance on Base"
 → Tool: get_wallet_info(chain_id=8453)
-→ Result: { walletAddress: "0x...", balances: [{ token: "ETH", balance: "0.5" }, ...] }
+→ Result: { walletAddress: "0x...", balances: [...] }
 
 Agent: "Swap 0.1 ETH for USDC on Base"
 → Tool: simulate_swap(from_token="ETH", to_token="USDC", amount_in="0.1", chain_id=8453)
-→ Tool: execute_swap(from_token="ETH", to_token="USDC", amount_in="0.1", chain_id=8453, simulation_id="sim_xxx")
-→ Result: { transactionId: "tx_xxx", status: "SUBMITTED" }
+→ Tool: execute_swap(..., simulation_id="sim_xxx")
 
-Agent: "Deposit 100 USDC into Aave on Base"
-→ Tool: deposit_aave(token="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", amount="100", chain_id=8453)
-→ Result: { transactionId: "tx_yyy", status: "SUBMITTED" }
+Agent: "Deposit 100 USDC into Compound V3 on Base"
+→ Tool: supply_compound(asset="0x833589...", amount="100", chain_id=8453)
+
+Agent: "Pay agent clx... 0.01 ETH for a market analysis job"
+→ Tool: post_job(provider_id="clx...", payload={...}, reward={amount:"0.01", token:"ETH"})
 ```
 
 ## Keywords
 
-mcp, defi, ethereum, base, arbitrum, polygon, ai-agents, uniswap, aave, turnkey, safe, smart-wallet, on-chain
+mcp, defi, ethereum, base, arbitrum, polygon, ai-agents, uniswap, curve, aave, compound, erc4626, a2a, turnkey, safe, smart-wallet, on-chain
 
 ## License
 


### PR DESCRIPTION
## Summary

Post-audit fixes to bring documentation in line with the actual codebase after the Phase 3 + Phase 4 v1 sprint. All content changes, no code touched.

## Files updated

| File | Change |
|------|--------|
| `README.md` | Key Features now list Compound/ERC-4626/Curve/A2A/P&L; MCP tool count corrected (10+ → 26) |
| `docs/architecture/overview.md` | Layer 4 shows 26 tools; protocols list expanded; new "Agent-to-Agent Layer" section |
| `docs/api-reference.md` | Clarifies 16-tool proxy vs 26-tool standalone package; documents Job escrow fields |
| `docs/project/go-live-status.md` | Removes Curve + Fastify v5 from "Still pending"; adds them to completed |
| `packages/mcp-server/README.md` | Rewritten from 10 tools to 26, organized by category; namespace fix |
| `packages/backend/README.md` | Fastify 4 → 5; namespace fix; services directory expanded |

## Verification

All docs checked against:
- Actual tool counts via `grep "name: '" packages/mcp-server/src/tools/*.ts` (26) and `packages/backend/src/api/routes/mcp.ts` (16)
- Actual package.json version (fastify ^5.8.5, mcp-server 0.2.0)
- Actual file count in migrations/ (0001-0005)

## Test plan

- [x] Grep-based verification of tool counts and versions
- [ ] CI green (docs-only, should be fast)