### PR TITLE
feat(phase4): P&L v2 — gas cost tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent P&L v2 — Gas cost tracking (Phase 4)**: `PnLService` now counts real gas burn as a cost category
+- Migration 0006: adds `effectiveGasPriceWei` TEXT to `Transaction`
+- `MonitorService` persists `receipt.effectiveGasPrice` at confirmation time (same for E2E test poller)
+- New cost category `costs.gas` in the P&L breakdown — `usd = gasUsed * effectiveGasPriceWei * ETH/USD`, summed across CONFIRMED + REVERTED txs in the period (REVERTED txs still burn gas on-chain)
+- Pre-migration rows with missing `gasUsed`/`effectiveGasPriceWei` are skipped and reported in `notes`
+- `PnLService` constructor now accepts an optional `PrismaClient` (defaults to the shared client) so it is unit-testable without a live DB
+- New unit test `pnl.service.test.ts` — 8 cases covering gas math, REVERTED handling, missing-row skipping, profitability thresholds
 - **Fastify upgraded to v5** — resolves the last HIGH npm vulnerability (DoS via sendWebStream, content-type tab bypass, X-Forwarded-Proto spoofing). All plugins were already v5-compatible from prior Dependabot updates — zero code changes needed.
 - `packages/mcp-server/RELEASE.md` — complete publish guide for bumping the mcp-server npm package (versioning, keywords, npm publish, git tags, MCP directory submissions)
 - **Curve Finance StableSwap adapter**: `POST /v1/transactions/swap-curve` — token-to-token swaps on any Curve classic pool (3pool, tri-pool, etc.)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,10 +35,40 @@ Rate limits are tier-based (FREE / PRO / ENTERPRISE) and keyed by `agentId` or I
 | GET | `/v1/agents/:id/manifest` | Public | Service manifest for A2A discovery |
 | PATCH | `/v1/agents/me/manifest` | Agent | Update own service manifest |
 | GET | `/v1/agents/:id/trust-report` | Public | Reputation score, A2A tx count |
-| GET | `/v1/agents/me/pnl` | Agent | Profit & loss breakdown (earnings, costs, breakeven) |
+| GET | `/v1/agents/me/pnl` | Agent | Profit & loss breakdown (earnings, costs incl. gas, breakeven) |
 | POST | `/v1/agents/me/sign-handshake` | Agent | **501** - Not implemented |
 | POST | `/v1/agents/verify-handshake` | Public | **501** - Not implemented |
 | DELETE | `/v1/agents/:id` | Agent (owner) | Soft deactivate + emergency pause |
+
+### GET /v1/agents/me/pnl
+
+Optional query: `?since=<ISO8601>` (defaults to agent's `createdAt`).
+
+```json
+// Response 200
+{
+  "agentId": "clx...",
+  "name": "MyAgent",
+  "periodStart": "2026-01-01T00:00:00.000Z",
+  "periodEnd": "2026-04-17T00:00:00.000Z",
+  "earnings": {
+    "a2aJobsAsProvider": { "count": 3, "usd": "100.000000" },
+    "totalEarningsUsd": "100.000000"
+  },
+  "costs": {
+    "protocolFees":        { "count": 12, "usd": "4.500000" },
+    "a2aJobsAsRequester":  { "count": 1,  "usd": "20.000000" },
+    "gas":                 { "count": 14, "usd": "6.320000" },
+    "totalCostsUsd": "30.820000"
+  },
+  "netPnlUsd": "69.180000",
+  "breakEven": true,
+  "profitable": true,
+  "notes": ["Realized yield from DEPOSIT transactions not included (needs on-chain reads)."]
+}
+```
+
+Gas cost = `gasUsed * effectiveGasPriceWei` per CONFIRMED/REVERTED tx, converted to USD via the native-token price oracle. REVERTED txs still burn gas and are counted.
 
 ### POST /v1/agents (Register)
 

--- a/packages/backend/src/__tests__/e2e/transaction.e2e.ts
+++ b/packages/backend/src/__tests__/e2e/transaction.e2e.ts
@@ -149,6 +149,8 @@ vi.mock('../../services/transaction/monitor.service.js', async () => {
                 data: {
                   status: confirmed ? 'CONFIRMED' : 'REVERTED',
                   gasUsed: receipt.gasUsed.toString(),
+                  effectiveGasPriceWei:
+                    receipt.effectiveGasPrice?.toString() ?? null,
                   confirmedAt: new Date(),
                 },
               });

--- a/packages/backend/src/__tests__/pnl.service.test.ts
+++ b/packages/backend/src/__tests__/pnl.service.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests — PnLService
+ *
+ * Validates profit & loss computation:
+ *  - earnings from A2A jobs as provider
+ *  - costs: protocol fees + A2A rewards paid + gas (v2)
+ *  - gas cost computed from gasUsed * effectiveGasPriceWei per CONFIRMED/REVERTED tx
+ *  - rows with missing gasUsed/effectiveGasPriceWei are skipped with a note
+ *
+ * Prisma is mocked; CoinGecko is stubbed via `fetch` at ETH=$2000.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PnLService } from '../services/billing/pnl.service.js';
+import { clearPriceCache } from '../services/transaction/price.service.js';
+import type { PrismaClient } from '@prisma/client';
+
+const ETH_USD = 2000;
+const mockFetch = vi.fn();
+
+function stubPrice() {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      ethereum: { usd: ETH_USD },
+      'matic-network': { usd: ETH_USD },
+    }),
+  });
+}
+
+interface MockOpts {
+  jobsAsProvider?: Array<{ reward: unknown }>;
+  jobsAsRequester?: Array<{ reward: unknown }>;
+  feeEvents?: Array<{ feeUsd: string }>;
+  transactions?: Array<{
+    chainId: number;
+    gasUsed: string | null;
+    effectiveGasPriceWei: string | null;
+  }>;
+}
+
+function makeMockDb(opts: MockOpts = {}): PrismaClient {
+  return {
+    agent: {
+      findUnique: vi.fn().mockResolvedValue({
+        id: 'agent-1',
+        name: 'Test Agent',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      }),
+    },
+    job: {
+      findMany: vi.fn().mockImplementation(({ where }: { where: { providerId?: string; requesterId?: string } }) => {
+        if (where.providerId) return Promise.resolve(opts.jobsAsProvider ?? []);
+        if (where.requesterId) return Promise.resolve(opts.jobsAsRequester ?? []);
+        return Promise.resolve([]);
+      }),
+    },
+    feeEvent: {
+      findMany: vi.fn().mockResolvedValue(opts.feeEvents ?? []),
+    },
+    transaction: {
+      findMany: vi.fn().mockResolvedValue(opts.transactions ?? []),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe('PnLService.computeAgentPnL', () => {
+  beforeEach(() => {
+    clearPriceCache();
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    stubPrice();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns zero P&L for an agent with no activity', async () => {
+    const svc = new PnLService(makeMockDb());
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(result.agentId).toBe('agent-1');
+    expect(result.earnings.totalEarningsUsd).toBe('0.000000');
+    expect(result.costs.totalCostsUsd).toBe('0.000000');
+    expect(result.costs.gas.count).toBe(0);
+    expect(result.costs.gas.usd).toBe('0.000000');
+    expect(result.netPnlUsd).toBe('0.000000');
+    expect(result.breakEven).toBe(true);
+    expect(result.profitable).toBe(false);
+  });
+
+  it('counts gas cost from gasUsed * effectiveGasPriceWei for a CONFIRMED tx', async () => {
+    // gasUsed=100_000, effectiveGasPrice=30 gwei → 3e15 wei → 0.003 ETH → $6 at $2000/ETH
+    const db = makeMockDb({
+      transactions: [
+        {
+          chainId: 1,
+          gasUsed: '100000',
+          effectiveGasPriceWei: '30000000000', // 30 gwei
+        },
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(result.costs.gas.count).toBe(1);
+    expect(parseFloat(result.costs.gas.usd)).toBeCloseTo(6, 2);
+    expect(parseFloat(result.costs.totalCostsUsd)).toBeCloseTo(6, 2);
+    expect(parseFloat(result.netPnlUsd)).toBeCloseTo(-6, 2);
+    expect(result.profitable).toBe(false);
+  });
+
+  it('counts gas for REVERTED tx too (gas still burns)', async () => {
+    const db = makeMockDb({
+      transactions: [
+        {
+          chainId: 1,
+          gasUsed: '50000',
+          effectiveGasPriceWei: '20000000000', // 20 gwei → 0.001 ETH → $2
+        },
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(result.costs.gas.count).toBe(1);
+    expect(parseFloat(result.costs.gas.usd)).toBeCloseTo(2, 2);
+  });
+
+  it('skips txs missing gasUsed or effectiveGasPriceWei and adds a note', async () => {
+    const db = makeMockDb({
+      transactions: [
+        { chainId: 1, gasUsed: null, effectiveGasPriceWei: '20000000000' },
+        { chainId: 1, gasUsed: '50000', effectiveGasPriceWei: null },
+        { chainId: 1, gasUsed: '100000', effectiveGasPriceWei: '30000000000' },
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(result.costs.gas.count).toBe(1);
+    expect(parseFloat(result.costs.gas.usd)).toBeCloseTo(6, 2);
+    expect(result.notes.some((n) => n.includes('2 tx(s) skipped'))).toBe(true);
+  });
+
+  it('sums all cost categories into totalCostsUsd', async () => {
+    const db = makeMockDb({
+      feeEvents: [{ feeUsd: '1.50' }, { feeUsd: '2.50' }],
+      jobsAsRequester: [
+        { reward: { amount: '0.01', token: 'ETH', chainId: 1 } }, // $20
+      ],
+      transactions: [
+        { chainId: 1, gasUsed: '100000', effectiveGasPriceWei: '30000000000' }, // $6
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(parseFloat(result.costs.protocolFees.usd)).toBeCloseTo(4, 2);
+    expect(parseFloat(result.costs.a2aJobsAsRequester.usd)).toBeCloseTo(20, 2);
+    expect(parseFloat(result.costs.gas.usd)).toBeCloseTo(6, 2);
+    expect(parseFloat(result.costs.totalCostsUsd)).toBeCloseTo(30, 2);
+  });
+
+  it('marks profitable=true when earnings exceed costs', async () => {
+    const db = makeMockDb({
+      jobsAsProvider: [
+        { reward: { amount: '0.05', token: 'ETH', chainId: 1 } }, // $100
+      ],
+      transactions: [
+        { chainId: 1, gasUsed: '100000', effectiveGasPriceWei: '30000000000' }, // $6
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    expect(parseFloat(result.earnings.totalEarningsUsd)).toBeCloseTo(100, 2);
+    expect(parseFloat(result.netPnlUsd)).toBeCloseTo(94, 2);
+    expect(result.profitable).toBe(true);
+    expect(result.breakEven).toBe(true);
+  });
+
+  it('handles invalid gasUsed/effectiveGasPriceWei without throwing', async () => {
+    const db = makeMockDb({
+      transactions: [
+        { chainId: 1, gasUsed: 'not-a-number', effectiveGasPriceWei: '30000000000' },
+      ],
+    });
+    const svc = new PnLService(db);
+    const result = await svc.computeAgentPnL({ agentId: 'agent-1' });
+
+    // BigInt('not-a-number') throws → caught → counted as missing
+    expect(result.costs.gas.count).toBe(0);
+    expect(result.notes.some((n) => n.includes('skipped'))).toBe(true);
+  });
+
+  it('throws when agent does not exist', async () => {
+    const db = {
+      agent: { findUnique: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const svc = new PnLService(db);
+
+    await expect(svc.computeAgentPnL({ agentId: 'missing' })).rejects.toThrow(
+      /not found/,
+    );
+  });
+});

--- a/packages/backend/src/db/migrations/0006_tx_gas_price/migration.sql
+++ b/packages/backend/src/db/migrations/0006_tx_gas_price/migration.sql
@@ -1,0 +1,10 @@
+-- Migration: 0006_tx_gas_price
+-- Purpose: Add effectiveGasPriceWei to Transaction so that P&L v2 can compute
+--          real gas costs (gasUsed * effectiveGasPrice) per confirmed tx.
+--
+-- v1 P&L left gas as a deferred cost because only gasUsed was persisted;
+-- with the effective gas price captured at receipt time, P&L now reports
+-- an accurate `profitable` flag.
+
+ALTER TABLE "Transaction"
+  ADD COLUMN IF NOT EXISTS "effectiveGasPriceWei" TEXT;

--- a/packages/backend/src/db/schema.prisma
+++ b/packages/backend/src/db/schema.prisma
@@ -162,6 +162,7 @@ model Transaction {
   amountOut      String?
   gasUsed        String?
   gasPrice       String?
+  effectiveGasPriceWei String?
   error          String?
   simulation     Json?
   metadata       Json?

--- a/packages/backend/src/services/billing/pnl.service.ts
+++ b/packages/backend/src/services/billing/pnl.service.ts
@@ -8,12 +8,13 @@
  * Earnings sources (v1):
  *   - A2A job rewards received (this agent as provider, status=COMPLETED)
  *
- * Cost sources (v1):
+ * Cost sources (v2):
  *   - Protocol fees paid (FeeEvent records linked via AgentBilling)
  *   - A2A job rewards paid out (this agent as requester, status=COMPLETED)
+ *   - Gas costs: gasUsed * effectiveGasPriceWei per CONFIRMED/REVERTED tx
+ *     (REVERTED txs still burn gas, so they are counted)
  *
- * Deferred to v2:
- *   - Gas costs (gasPrice not reliably stored at confirmation time)
+ * Deferred to future:
  *   - Realized yield from DEPOSIT transactions (needs on-chain reads)
  *
  * USD conversion uses the same price oracle as the fee and escrow services.
@@ -21,7 +22,8 @@
  */
 
 import { parseEther, parseUnits } from 'viem';
-import { db } from '../../db/client.js';
+import type { PrismaClient } from '@prisma/client';
+import { db as defaultDb } from '../../db/client.js';
 import { weiToUsd, tokenAmountToUsd } from '../transaction/price.service.js';
 import { logger } from '../../api/middleware/logger.js';
 
@@ -37,6 +39,7 @@ export interface PnLBreakdown {
   costs: {
     protocolFees: { count: number; usd: string };
     a2aJobsAsRequester: { count: number; usd: string };
+    gas: { count: number; usd: string };
     totalCostsUsd: string;
   };
   netPnlUsd: string;
@@ -76,6 +79,12 @@ async function rewardToUsd(reward: RewardJson | null): Promise<string> {
 }
 
 export class PnLService {
+  private readonly db: PrismaClient;
+
+  constructor(db: PrismaClient = defaultDb) {
+    this.db = db;
+  }
+
   /**
    * Computes P&L for a single agent.
    * @param agentId - the agent to analyze
@@ -85,7 +94,7 @@ export class PnLService {
     agentId: string;
     since?: Date;
   }): Promise<PnLBreakdown> {
-    const agent = await db.agent.findUnique({
+    const agent = await this.db.agent.findUnique({
       where: { id: params.agentId },
       select: { id: true, name: true, createdAt: true },
     });
@@ -99,7 +108,7 @@ export class PnLService {
     const notes: string[] = [];
 
     // --- Earnings: A2A jobs as provider (COMPLETED) ---
-    const jobsAsProvider = await db.job.findMany({
+    const jobsAsProvider = await this.db.job.findMany({
       where: {
         providerId: agent.id,
         status: 'COMPLETED',
@@ -115,7 +124,7 @@ export class PnLService {
     }
 
     // --- Costs: protocol fees paid ---
-    const feeEvents = await db.feeEvent.findMany({
+    const feeEvents = await this.db.feeEvent.findMany({
       where: {
         billing: { agentId: agent.id },
         collectedAt: { gte: periodStart },
@@ -129,7 +138,7 @@ export class PnLService {
     );
 
     // --- Costs: A2A jobs as requester (COMPLETED) ---
-    const jobsAsRequester = await db.job.findMany({
+    const jobsAsRequester = await this.db.job.findMany({
       where: {
         requesterId: agent.id,
         status: 'COMPLETED',
@@ -144,16 +153,54 @@ export class PnLService {
       rewardsPaidUsd += parseFloat(usd);
     }
 
-    // Deferred items — surface in notes rather than silently skipping.
+    // --- Costs: gas burned on confirmed/reverted txs ---
+    // REVERTED txs still burn gas on-chain, so they are counted as a real cost.
+    // Txs with missing gasUsed or effectiveGasPriceWei (older rows pre-migration)
+    // are silently skipped rather than biasing the total toward zero.
+    const gasTxs = await this.db.transaction.findMany({
+      where: {
+        agentId: agent.id,
+        status: { in: ['CONFIRMED', 'REVERTED'] },
+        confirmedAt: { gte: periodStart },
+      },
+      select: {
+        chainId: true,
+        gasUsed: true,
+        effectiveGasPriceWei: true,
+      },
+    });
+
+    let gasCostsUsd = 0;
+    let gasCostedTxCount = 0;
+    let gasMissingCount = 0;
+    for (const tx of gasTxs) {
+      if (!tx.gasUsed || !tx.effectiveGasPriceWei) {
+        gasMissingCount++;
+        continue;
+      }
+      try {
+        const gasCostWei =
+          BigInt(tx.gasUsed) * BigInt(tx.effectiveGasPriceWei);
+        const usd = await weiToUsd(gasCostWei, tx.chainId);
+        gasCostsUsd += parseFloat(usd);
+        gasCostedTxCount++;
+      } catch {
+        gasMissingCount++;
+      }
+    }
+
+    if (gasMissingCount > 0) {
+      notes.push(
+        `${gasMissingCount} tx(s) skipped in gas cost calc (missing gasUsed/effectiveGasPriceWei — likely pre-migration rows).`,
+      );
+    }
+
     notes.push(
-      'Gas costs not included in v1 (gasPrice not tracked at confirmation).',
-    );
-    notes.push(
-      'Realized yield from DEPOSIT transactions not included in v1.',
+      'Realized yield from DEPOSIT transactions not included (needs on-chain reads).',
     );
 
     const totalEarningsUsd = earningsUsd;
-    const totalCostsUsd = protocolFeesUsd + rewardsPaidUsd;
+    const totalCostsUsd = protocolFeesUsd + rewardsPaidUsd + gasCostsUsd;
     const netPnlUsd = totalEarningsUsd - totalCostsUsd;
 
     const breakdown: PnLBreakdown = {
@@ -176,6 +223,10 @@ export class PnLService {
         a2aJobsAsRequester: {
           count: jobsAsRequester.length,
           usd: rewardsPaidUsd.toFixed(6),
+        },
+        gas: {
+          count: gasCostedTxCount,
+          usd: gasCostsUsd.toFixed(6),
         },
         totalCostsUsd: totalCostsUsd.toFixed(6),
       },

--- a/packages/backend/src/services/transaction/monitor.service.ts
+++ b/packages/backend/src/services/transaction/monitor.service.ts
@@ -39,17 +39,25 @@ export class MonitorService {
 
         if (receipt) {
           const confirmed = receipt.status === 'success';
+          const effectiveGasPriceWei =
+            receipt.effectiveGasPrice?.toString() ?? null;
           await this.db.transaction.update({
             where: { id: transactionId },
             data: {
               status: confirmed ? 'CONFIRMED' : 'REVERTED',
               gasUsed: receipt.gasUsed.toString(),
+              effectiveGasPriceWei,
               confirmedAt: new Date(),
             },
           });
 
           logger.info(
-            { txHash, status: receipt.status, gasUsed: receipt.gasUsed },
+            {
+              txHash,
+              status: receipt.status,
+              gasUsed: receipt.gasUsed,
+              effectiveGasPriceWei,
+            },
             'Transaction confirmed',
           );
           return;


### PR DESCRIPTION
## Summary

- Adds **gas cost** as a new category in the agent P&L breakdown so the `profitable` flag reflects the full on-chain economics of each agent
- Persists `receipt.effectiveGasPrice` at confirmation (monitor + E2E poller) via new migration `0006_tx_gas_price`
- REVERTED txs count toward gas cost (they still burn on-chain); pre-migration rows are skipped with a note

Closes Task **A** from [HANDOFF.md](HANDOFF.md) — *Pending Technical Roadmap → P&L v2 (gas cost tracking)*.

## Changes

### Schema / Data
- Migration **0006**: `ALTER TABLE "Transaction" ADD COLUMN IF NOT EXISTS "effectiveGasPriceWei" TEXT`
- `schema.prisma`: new optional field `effectiveGasPriceWei String?` on `Transaction`

### Runtime
- `MonitorService.waitForConfirmation` now reads `receipt.effectiveGasPrice` and persists it alongside `gasUsed`
- E2E test poller (`transaction.e2e.ts`) updated identically so smoke tests capture gas price
- `PnLService`:
  - New `costs.gas = { count, usd }` in `PnLBreakdown`
  - `gasUsed * effectiveGasPriceWei` summed across CONFIRMED + REVERTED in the period, `weiToUsd`-converted per chain
  - Missing-value rows produce a `notes` entry instead of biasing totals
  - Constructor now accepts an optional `PrismaClient` (defaults to shared client) so it's unit-testable

### Tests
- New unit suite `pnl.service.test.ts` — 8 cases: empty agent, CONFIRMED gas math, REVERTED gas math, mixed missing rows, full cost sum, profitable-threshold, invalid gasUsed, missing agent

### Docs
- `CHANGELOG.md` — P&L v2 entry added to [Unreleased]
- `docs/api-reference.md` — full response schema added for `GET /v1/agents/me/pnl`, including the new `gas` cost key

## Local verification

- `npm run typecheck --workspaces` → 4/4 green
- `vitest run <unit suites>` → 45/45 passing (includes 8 new PnL cases)
- DB-integration tests (`agent.search.test.ts`) skipped locally (no local Postgres) — rely on CI

## Test plan

- [ ] CI: all 6 status checks green (Deploy Preflight, Lint & Type Check, Admin Tests, Backend Tests, Foundry Tests, E2E Tests)
- [ ] Backend Tests job runs migration 0006 via `prisma migrate deploy`
- [ ] E2E Tests job captures `effectiveGasPriceWei` on Anvil receipts
- [ ] (Optional) post-merge: verify on a live agent that `/v1/agents/me/pnl` returns a non-zero `costs.gas.usd` after its next tx

🤖 Generated with [Claude Code](https://claude.com/claude-code)