### PR TITLE
feat(mcp)!: rename request_policy_update → update_policy (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (breaking — mcp-server 0.2.0 → 0.3.0)
+- **MCP tool rename: `request_policy_update` → `update_policy`.** Closes step 6 of [#49](https://github.com/felippeyann/agentfi/issues/49). The old name + description implied an operator-approval workflow; the tool actually wrote the policy immediately. Renamed honestly and rewrote the description: *"applies IMMEDIATELY — there is no operator approval step. The operator can audit and revert via the admin panel."* `reason` field is still required and logged for audit but does not gate the write. `@agent_fi/mcp-server` bumped to **0.3.0** (SemVer breaking); no deprecated alias — pre-1.0 project, clean rename.
+
 ### Added
 - **A2A handshake — `sign_handshake` / `verify_handshake` implemented.** Closes steps 3–5 of [#49](https://github.com/felippeyann/agentfi/issues/49); previously both returned 501.
   - `POST /v1/agents/me/sign-handshake` now signs an arbitrary message with the agent's wallet via EIP-191 `personal_sign`. `LocalWalletService` uses viem's `signMessage`; `TurnkeyService` uses `signRawPayload` with `HASH_FUNCTION_NO_OP` after pre-hashing with viem's `hashMessage`, then assembles a standard 65-byte r‖s‖v signature.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -68,9 +68,9 @@ Built on the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) sta
 | `check_inbox` | Fetch jobs assigned to you (as provider) |
 | `update_job_status` | Accept / complete / fail / cancel a job |
 | `pay_agent` | Pay another agent directly (outside the job queue) |
-| `request_policy_update` | Propose a policy change (operator-approved) |
-| `sign_handshake` | Sign an A2A identity handshake message (501 — v3 roadmap) |
-| `verify_handshake` | Verify a peer's handshake signature (501 — v3 roadmap) |
+| `update_policy` | Update the agent's own operational policy (applies immediately; operator can revert via admin) |
+| `sign_handshake` | Sign an A2A identity handshake message (EIP-191 `personal_sign`) |
+| `verify_handshake` | Verify a peer's handshake signature (ECDSA + EIP-1271 fallback) |
 
 ## Installation
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent_fi/mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },
   "description": "AgentFi MCP Server — crypto transaction tools for AI agents",

--- a/packages/mcp-server/src/tools/agent.ts
+++ b/packages/mcp-server/src/tools/agent.ts
@@ -54,16 +54,18 @@ export const agentTools = [
   },
 
   {
-    name: 'request_policy_update',
+    name: 'update_policy',
     description:
-      'Autonomously requests a change to the agent\'s own operational policy. ' +
+      'Updates the agent\'s own operational policy. ' +
+      'The change applies IMMEDIATELY — there is no operator approval step. ' +
+      'The operator can audit and revert via the admin panel. ' +
       'Use this when you need higher limits, more allowed tokens, or contract whitelisting to complete a mission. ' +
-      'The request must be justified by your current goals.',
+      'Provide a `reason` for audit — it is logged but does not gate the change.',
     inputSchema: z.object({
-      max_value_per_tx_eth: z.string().optional().describe('Requested new max ETH per transaction.'),
+      max_value_per_tx_eth: z.string().optional().describe('New max ETH per transaction.'),
       allowed_tokens: z.array(z.string()).optional().describe('New tokens to add to whitelist.'),
       allowed_contracts: z.array(z.string()).optional().describe('New contracts to add to whitelist.'),
-      reason: z.string().describe('Detailed justification for why this policy change is needed.'),
+      reason: z.string().describe('Justification for the change — recorded in audit log, does not gate the write.'),
     }),
     handler: async (input: {
       max_value_per_tx_eth?: string;
@@ -73,7 +75,7 @@ export const agentTools = [
     }) => {
       // Get current agent ID first
       const me = await api.get<{ id: string }>('/v1/agents/me');
-      
+
       const result = await api.patch(`/v1/agents/${me.id}/policy`, {
         maxValuePerTxEth: input.max_value_per_tx_eth,
         allowedTokens: input.allowed_tokens,
@@ -83,7 +85,7 @@ export const agentTools = [
       return {
         success: true,
         updatedPolicy: result,
-        audit: `Policy update requested autonomously. Reason: ${input.reason}`,
+        audit: `Policy updated by agent. Reason: ${input.reason}`,
       };
     },
   },


### PR DESCRIPTION
## Summary

**Closes the final step (6) of [#49](https://github.com/felippeyann/agentfi/issues/49)** — and therefore closes the issue entirely.

The old MCP tool name `request_policy_update` and its description implied an operator-approval workflow that does not exist. The tool writes the new policy **immediately** via `PATCH /v1/agents/:id/policy` with no review. Renaming honestly + rewriting the description so LLMs aren't misled into false safety assumptions.

**Breaking change** for MCP clients — `@agent_fi/mcp-server` bumped **0.2.0 → 0.3.0** (SemVer). No deprecated alias.

## Changes

### `packages/mcp-server/src/tools/agent.ts`
- Tool renamed: `request_policy_update` → `update_policy`
- Description rewritten:
  > *\"Updates the agent's own operational policy. The change applies IMMEDIATELY — there is no operator approval step. The operator can audit and revert via the admin panel. [...] Provide a `reason` for audit — it is logged but does not gate the change.\"*
- `reason` field kept (still required, logged in audit trail) but clarified as non-gating

### Version
- `packages/mcp-server/package.json`: `0.2.0` → `0.3.0`

### Docs
- `packages/mcp-server/README.md`: tool table now reflects `update_policy` + live `sign_handshake` / `verify_handshake` (no longer 501)
- `CHANGELOG.md`: new `Changed (breaking — mcp-server 0.2.0 → 0.3.0)` section with rationale

## Why no alias

- Package is pre-1.0 (0.2.0 on npm at time of writing) — SemVer explicitly allows breaking changes in `0.x`.
- MCP clients introspect the tool list at connect time; an alias would show two tools with identical behavior, which is actively confusing.
- The package just hit the registry a couple days ago; there are no known production dependents to protect.

## Post-merge action required

Maintainer needs to publish `@agent_fi/mcp-server@0.3.0` to npm. See the publish section of [HANDOFF.md](HANDOFF.md) / [packages/mcp-server/RELEASE.md](packages/mcp-server/RELEASE.md).

Commands:
```bash
cd packages/mcp-server
npm run build
npm publish --access public
# then: git tag mcp-server-v0.3.0 && git push origin mcp-server-v0.3.0 && gh release create ...
```

## With this PR, #49 is fully resolved

| Step | Resolved in |
|---|---|
| 1. Self-registration gated by API_SECRET | [#50](https://github.com/felippeyann/agentfi/pull/50) |
| 2. MCP chicken-and-egg with API key | [#50](https://github.com/felippeyann/agentfi/pull/50) (register via public endpoint) |
| 3. `sign_handshake` 501 | [#51](https://github.com/felippeyann/agentfi/pull/51) |
| 4. `verify_handshake` 501 | [#51](https://github.com/felippeyann/agentfi/pull/51) |
| 5. `post_job` depends on handshake | [#51](https://github.com/felippeyann/agentfi/pull/51) |
| 6. `request_policy_update` misleading | **this PR** |

## Test plan

- [ ] CI: 6 green checks (5 required + OpenAPI Spec)
- [x] Typecheck green on all 4 workspaces
- [x] `packages/mcp-server/dist/` rebuilds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)