### PR TITLE
docs: sync post-release @agent_fi/mcp-server@0.3.0

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For *what the project is*, read [STATE.md](STATE.md). For *why*, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: April 2026 · **main SHA** `63b76a6` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.2.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
+**Last updated**: April 2026 · **main SHA** `700c76c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
 
 ---
 

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the *why*) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project *is* today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: April 2026 · **main SHA** `63b76a6` · **npm** `@agent_fi/mcp-server@0.2.0`
+**Last updated**: April 2026 · **main SHA** `700c76c` · **npm** `@agent_fi/mcp-server@0.3.0`
 
 ---
 
@@ -205,8 +205,8 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 |---|---|---|
 | Source code | https://github.com/felippeyann/agentfi | Apache 2.0, public |
 | Release | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0 | v0.1.0 (April 2026) |
-| mcp-server npm | https://www.npmjs.com/package/@agent_fi/mcp-server | **v0.2.0** |
-| mcp-server release | https://github.com/felippeyann/agentfi/releases/tag/mcp-server-v0.2.0 | published |
+| mcp-server npm | https://www.npmjs.com/package/@agent_fi/mcp-server | **v0.3.0** (breaking: `request_policy_update` → `update_policy`) |
+| mcp-server releases | https://github.com/felippeyann/agentfi/releases | v0.1.0, v0.2.0, v0.3.0 all published |
 | mcp.so listing | https://mcp.so/server/agentfi-mcp-server/felippeyann | submitted (pending review) |
 | awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091 | open (pending maintainer merge) |
 | Base contracts | `0x03af…6A6d` + `0x5441…24b3` | verified on Basescan |

--- a/docs/dev-quickstart.md
+++ b/docs/dev-quickstart.md
@@ -108,7 +108,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "agentfi-dev": {
       "command": "npx",
-      "args": ["-y", "@agent_fi/mcp-server@0.2.0"],
+      "args": ["-y", "@agent_fi/mcp-server@0.3.0"],
       "env": {
         "AGENTFI_API_URL": "http://localhost:3000",
         "AGENTFI_API_KEY": "agfi_live_..."


### PR DESCRIPTION
STATE.md + HANDOFF.md + dev-quickstart snippet updated to reflect the published 0.3.0 on npm. Main SHA bumped to 700c76c.