### PR TITLE
docs: sync main SHA refs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For *what the project is*, read [STATE.md](STATE.md). For *why*, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: April 2026 · **main SHA** `700c76c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
+**Last updated**: April 2026 · **main SHA** `084a086` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
 
 ---
 

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the *why*) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project *is* today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: April 2026 · **main SHA** `700c76c` · **npm** `@agent_fi/mcp-server@0.3.0`
+**Last updated**: April 2026 · **main SHA** `084a086` · **npm** `@agent_fi/mcp-server@0.3.0`
 
 ---
 


### PR DESCRIPTION
Trailing fix after PR #54. STATE.md + HANDOFF.md now reference the current main SHA 084a086.