### PR TITLE
fix(backend): ADMIN_SECRET min-32 validation + Discord/Telegram operator notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,26 @@ BACKEND_URL=http://localhost:3000
 
 
 # -----------------------------------------------------------------------------
+# Operator Notifications
+# -----------------------------------------------------------------------------
+# When set, the backend posts JSON payloads for PENDING_APPROVAL / TRANSACTION_*
+# events to the configured channels.
+
+# Generic webhook URL (any HTTP endpoint that accepts POST JSON — e.g. n8n, Zapier)
+OPERATOR_NOTIFICATION_WEBHOOK=
+
+# Discord: paste a Discord channel webhook URL
+# https://support.discord.com/hc/en-us/articles/228383668
+OPERATOR_DISCORD_WEBHOOK=
+
+# Telegram: create a bot via @BotFather, then set both values
+# OPERATOR_TELEGRAM_BOT_TOKEN=123456:ABC-your-bot-token
+# OPERATOR_TELEGRAM_CHAT_ID=-100your-chat-id
+OPERATOR_TELEGRAM_BOT_TOKEN=
+OPERATOR_TELEGRAM_CHAT_ID=
+
+
+# -----------------------------------------------------------------------------
 # Contracts (populated after on-chain deployment)
 # -----------------------------------------------------------------------------
 # Leave blank until the contracts are deployed. Each variable follows the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           DATABASE_URL: postgresql://agentfi:agentfi@localhost:5432/agentfi_e2e
           REDIS_URL: redis://localhost:6379
           API_SECRET: e2e-test-secret-min-32-chars-long
-          ADMIN_SECRET: e2e-admin-secret
+          ADMIN_SECRET: e2e-admin-secret-min-32-chars-long
           # Dummy values — Alchemy/Turnkey are bypassed by E2E mocks
           ALCHEMY_API_KEY: e2e-dummy
           TURNKEY_API_PUBLIC_KEY: e2e-dummy

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -68,7 +68,7 @@ const envSchema = z.object({
   STRIPE_PRO_PRICE_ID: z.string().optional(),
 
   // Admin dashboard — required to protect /admin/* routes
-  ADMIN_SECRET: z.string().min(1),
+  ADMIN_SECRET: z.string().min(32),
   ADMIN_ALLOW_REMOTE: z.enum(['true', 'false']).default('false'),
 
   // CORS — comma-separated allowed origins for the admin frontend in production.

--- a/packages/backend/src/services/notification.service.ts
+++ b/packages/backend/src/services/notification.service.ts
@@ -9,18 +9,91 @@ export interface NotificationPayload {
   metadata?: any;
 }
 
+// ─── Emoji + label helpers ────────────────────────────────────────────────────
+
+const TYPE_EMOJI: Record<NotificationPayload['type'], string> = {
+  PENDING_APPROVAL:      '🚨',
+  TRANSACTION_CONFIRMED: '✅',
+  TRANSACTION_FAILED:    '❌',
+  POLICY_VIOLATION:      '⛔',
+};
+
+function formatText(payload: NotificationPayload): string {
+  const { type, agentName, message, transactionId } = payload;
+  const emoji = TYPE_EMOJI[type];
+  const lines = [
+    `${emoji} *${type}*`,
+    `Agent: ${agentName}`,
+    message,
+  ];
+  if (transactionId) lines.push(`Tx: \`${transactionId}\``);
+  return lines.join('\n');
+}
+
+// ─── Adapters ─────────────────────────────────────────────────────────────────
+
+async function sendGenericWebhook(url: string, payload: NotificationPayload): Promise<void> {
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function sendDiscord(webhookUrl: string, payload: NotificationPayload): Promise<void> {
+  const { type, agentName, message, transactionId } = payload;
+  const emoji = TYPE_EMOJI[type];
+  const fields = [
+    { name: 'Agent', value: agentName, inline: true },
+    { name: 'Event', value: type, inline: true },
+  ];
+  if (transactionId) fields.push({ name: 'Transaction', value: transactionId, inline: false });
+
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      embeds: [{
+        title: `${emoji} ${type}`,
+        description: message,
+        color: type === 'PENDING_APPROVAL' ? 0xF59E0B
+          : type === 'TRANSACTION_CONFIRMED' ? 0x22C55E
+          : type === 'POLICY_VIOLATION' ? 0xEF4444
+          : 0x6B7280,
+        fields,
+        timestamp: new Date().toISOString(),
+      }],
+    }),
+  });
+}
+
+async function sendTelegram(
+  botToken: string,
+  chatId: string,
+  payload: NotificationPayload,
+): Promise<void> {
+  const text = formatText(payload);
+  await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: 'Markdown',
+    }),
+  });
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
 export class NotificationService {
-  /**
-   * Sends a notification to the operator.
-   * Currently logs to console, but can be extended to Webhooks, Discord, Telegram, etc.
-   */
   async notify(payload: NotificationPayload): Promise<void> {
     const { type, agentName, message, transactionId } = payload;
-    
-    // 1. Internal Log
+
+    // 1. Internal log
     logger.info({ ...payload }, `[Notification] ${type}: ${message}`);
 
-    // 2. Formatted Console Alert (for development/monitoring)
+    // 2. Console alert for PENDING_APPROVAL (dev convenience)
     if (type === 'PENDING_APPROVAL') {
       console.log('\n' + '='.repeat(50));
       console.log('🚨 ACTION REQUIRED: TRANSACTION AWAITING APPROVAL');
@@ -31,19 +104,38 @@ export class NotificationService {
       console.log('='.repeat(50) + '\n');
     }
 
-    // Future: Add Webhook support here
+    // 3. External channels — all fire in parallel, failures are non-fatal
+    const dispatches: Promise<void>[] = [];
+
     const webhookUrl = process.env['OPERATOR_NOTIFICATION_WEBHOOK'];
     if (webhookUrl) {
-      try {
-        await fetch(webhookUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
-      } catch (err) {
-        logger.warn({ err }, 'Failed to send notification webhook');
-      }
+      dispatches.push(
+        sendGenericWebhook(webhookUrl, payload).catch((err) =>
+          logger.warn({ err }, 'Failed to send generic webhook notification'),
+        ),
+      );
     }
+
+    const discordUrl = process.env['OPERATOR_DISCORD_WEBHOOK'];
+    if (discordUrl) {
+      dispatches.push(
+        sendDiscord(discordUrl, payload).catch((err) =>
+          logger.warn({ err }, 'Failed to send Discord notification'),
+        ),
+      );
+    }
+
+    const telegramToken = process.env['OPERATOR_TELEGRAM_BOT_TOKEN'];
+    const telegramChatId = process.env['OPERATOR_TELEGRAM_CHAT_ID'];
+    if (telegramToken && telegramChatId) {
+      dispatches.push(
+        sendTelegram(telegramToken, telegramChatId, payload).catch((err) =>
+          logger.warn({ err }, 'Failed to send Telegram notification'),
+        ),
+      );
+    }
+
+    await Promise.all(dispatches);
   }
 }
 


### PR DESCRIPTION
## Summary

- **#69 (Security)** — `ADMIN_SECRET` schema tightened from `z.string().min(1)` to `z.string().min(32)`, matching `API_SECRET`. The .env.example comment already required 32 chars; this aligns Zod validation with that expectation so weak secrets are rejected at boot.
- **#68 (Feature/UX)** — `NotificationService` now supports Discord (rich embeds with per-event-type colors) and Telegram in addition to the existing generic webhook. All channels fire in parallel via `Promise.all`; any channel failure is logged as `warn` and does not block the others. New env vars (`OPERATOR_DISCORD_WEBHOOK`, `OPERATOR_TELEGRAM_BOT_TOKEN`, `OPERATOR_TELEGRAM_CHAT_ID`, `OPERATOR_NOTIFICATION_WEBHOOK`) documented in `.env.example`.

## Test plan

- [ ] Boot with `ADMIN_SECRET=short` → server should exit with Zod validation error
- [ ] Boot with 32-char `ADMIN_SECRET` → server starts normally
- [ ] Set `OPERATOR_DISCORD_WEBHOOK` to a test Discord webhook → trigger a `PENDING_APPROVAL` event → confirm embed arrives in Discord channel
- [ ] Set `OPERATOR_TELEGRAM_BOT_TOKEN` + `OPERATOR_TELEGRAM_CHAT_ID` → trigger event → confirm Telegram message received
- [ ] Kill a webhook URL → confirm the other channels still fire and a `warn` log is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)