### PR TITLE
fix(backend): A2A revenue integrity — Phase 1 (ghost completions)

### DIFF
--- a/docs/project/issue-71-a2a-revenue-integrity.md
+++ b/docs/project/issue-71-a2a-revenue-integrity.md
@@ -1,0 +1,233 @@
+# Issue #71 — A2A Revenue Integrity (Execution Plan)
+
+**Issue:** [#71 — Critical: Inconsistent Revenue Calculation & Ghost Completions in A2A Jobs](https://github.com/felippeyann/agentfi/issues/71)
+**Status:** Phase 1 in progress (this plan opened 2026-05-03)
+**Owner:** felippeyann (root cause attributed to Gemini CLI analysis on the issue)
+
+This doc preserves the full investigation and 3-phase plan so any future agent
+picks up where we left off. Update the status table at the bottom as phases ship.
+
+---
+
+## 1. Bug surface (what's broken today)
+
+Three coupled bugs in the A2A job lifecycle that together produce
+"ghost revenue" in the PnL dashboard — money the protocol reports as earned
+that was never actually received on-chain.
+
+### 1.1 Ghost completions — fire-and-forget payment
+
+[`packages/backend/src/api/routes/jobs.ts`](../../packages/backend/src/api/routes/jobs.ts)
+in the `PATCH /v1/jobs/:id` handler:
+
+```ts
+// Lines 188-207 (pre-fix)
+executeA2APayment({...})
+  .then((result) => { logger.info(...) })
+  .catch((err) => { logger.error(..., 'manual resolution required') });
+```
+
+The job is updated to `COMPLETED` *before* this fire-and-forget call. If the
+on-chain transfer fails, the job stays `COMPLETED` in the DB but no funds
+arrived in the provider's wallet. The error log says "manual resolution
+required" — meaning the design accepts that operators must reconcile by hand.
+
+Side effects in the same path that compound the bug:
+
+- `reputationService.recordJobOutcome(job.providerId, true)` — provider
+  earns reputation for a failed payment.
+- `markEscrowReleased(job.id)` — escrow accounting marks funds as paid out
+  before any payment was attempted.
+
+### 1.2 Silent zero from price oracle
+
+[`packages/backend/src/services/transaction/price.service.ts`](../../packages/backend/src/services/transaction/price.service.ts)
+returns `0` as a fallback on **any** error (timeout, unknown token, network
+failure, rate limit). `PnLService` consumes that `0` as if it were a real
+USD price → historical revenue silently disappears when the oracle is down
+during dashboard rendering.
+
+### 1.3 Real-time price (no historical snapshot)
+
+PnL is computed at read time using *current* market prices, not the price
+at job-completion time. A token dropping 90% retroactively erases the
+agent's historical earnings. Financial history is volatile by design,
+which is wrong.
+
+---
+
+## 2. The 3-phase plan
+
+Phases are independent and can ship as separate PRs. Phase 1 unblocks
+Phase 3 (PnL can lean on the new state model), but Phase 2 can be done
+in parallel.
+
+### Phase 1 — Robust status transitions (this PR: `fix/a2a-revenue-integrity`)
+
+**Goal:** stop reporting revenue for failed payments. Job only reaches
+`COMPLETED` after the on-chain transfer confirms.
+
+**Approach chosen:** two-phase status with an intermediate `PAYMENT_PENDING`
+state, **not** synchronous `await` on the payment.
+
+Why not just `await executeA2APayment(...)` in the request handler?
+On-chain confirmation can take 10–30+ seconds (and longer on congested L1).
+Blocking the HTTP response that long causes proxy timeouts, breaks SDK
+clients with default 10s timeouts, and ties up Fastify worker threads
+during gas spikes. The async-with-state-machine pattern is the standard
+Web3 fix and matches how the rest of the codebase already handles
+transactions.
+
+**State machine:**
+
+```
+PENDING ──provider ACK───────► ACCEPTED
+ACCEPTED ──PATCH COMPLETED (no reward)─────► COMPLETED
+ACCEPTED ──PATCH COMPLETED (with reward)───► PAYMENT_PENDING
+PAYMENT_PENDING ──executeA2APayment ok─────► COMPLETED  (system)
+PAYMENT_PENDING ──executeA2APayment fail───► PAYMENT_FAILED  (system)
+ACCEPTED ──PATCH FAILED────────────────────► FAILED
+{PENDING, ACCEPTED} ──PATCH CANCELLED──────► CANCELLED
+```
+
+API contract: `VALID_TRANSITIONS` keeps exposing only `COMPLETED` /
+`FAILED` / `CANCELLED` to providers — the new states (`PAYMENT_PENDING`,
+`PAYMENT_FAILED`) are system-only and never accepted as input on the
+PATCH endpoint.
+
+**Side-effect placement (the real fix):**
+
+| Action                         | Old position                         | New position                                  |
+| ------------------------------ | ------------------------------------ | --------------------------------------------- |
+| `reputationService.record(...)` | Before payment fired                 | Inside `.then()` after payment confirms       |
+| `markEscrowReleased(jobId)`     | Before payment fired                 | Inside `.then()` after payment confirms       |
+| `releaseJobEscrow(jobId)` (refund) | Only on `FAILED`/`CANCELLED`      | Also inside `.catch()` of payment failure     |
+| Status `COMPLETED`              | Set immediately on PATCH             | Set inside `.then()` after payment confirms   |
+| Status `PAYMENT_PENDING`        | n/a                                  | Set immediately on PATCH for paid jobs        |
+| Status `PAYMENT_FAILED`         | n/a                                  | Set inside `.catch()` of payment failure      |
+
+**Files touched:**
+
+- `packages/backend/src/db/schema.prisma` — add `PAYMENT_PENDING` and
+  `PAYMENT_FAILED` to the `JobStatus` enum.
+- `packages/backend/src/db/migrations/0008_job_payment_status/migration.sql`
+  — hand-written `ALTER TYPE ... ADD VALUE` (Postgres requires these
+  outside a transaction in older server versions; we ship them as
+  separate statements).
+- `packages/backend/src/api/routes/jobs.ts` — split the `COMPLETED`
+  branch into rewarded vs. non-rewarded paths; move side effects into
+  the payment promise's `.then` / `.catch`.
+- Regenerate the Prisma client after schema edit (per `HANDOFF.md` §7):
+  `npx prisma generate --schema=packages/backend/src/db/schema.prisma`.
+
+**What this PR explicitly does *not* fix:**
+
+- **Server crash recovery** — if the backend dies between
+  `PAYMENT_PENDING` and the `.then()` resolving, the job stays
+  `PAYMENT_PENDING` forever. Needs a BullMQ recovery worker that scans
+  for stale `PAYMENT_PENDING` rows and re-checks tx status. Listed as
+  follow-up below.
+- **Dashboard surfacing** — the admin dashboard doesn't yet have a
+  `PAYMENT_PENDING` / `PAYMENT_FAILED` filter or column. Operators can
+  query directly until that ships.
+- **Payment service idempotency** — Phase 2 will need
+  `executeA2APayment` to be safely retryable.
+
+### Phase 2 — Revenue snapshots (separate PR)
+
+**Goal:** PnL history stops being volatile. The reward USD value is
+captured at the moment of completion, not recomputed at read time.
+
+**Schema additions** to the `Job` model:
+
+```prisma
+rewardUsd                String?    // Decimal as string, USD value at completion
+rewardPriceAtCompletion  String?    // Token price in USD at completion time
+rewardPriceSource        String?    // "alchemy" | "coingecko" | etc — for audit
+rewardPriceCapturedAt    DateTime?  // When the price was locked in
+```
+
+**Trigger:** when Phase 1's `.then()` runs (payment confirmed), call
+`PriceService` once, persist the snapshot atomically with the
+`COMPLETED` status update. If price resolution fails, persist `NULL`
++ keep status `PAYMENT_PENDING` until a retry succeeds, OR mark
+`COMPLETED` with a flag → operator decides via setting
+`PNL_REQUIRE_PRICE_FOR_COMPLETION` (recommend default false to
+avoid blocking on oracle outages).
+
+**Migration:** `0009_job_revenue_snapshot/migration.sql`.
+
+### Phase 3 — PnLService refactor (separate PR)
+
+**Goal:** stop silent zeros. Always prefer the snapshot. Surface oracle
+failures explicitly.
+
+**Changes:**
+
+- `PnLService.computeRevenue(...)` — for each `COMPLETED` job, prefer
+  `job.rewardUsd` if non-null. Fall back to live price *only* for
+  jobs predating Phase 2 schema (no snapshot available); flag those
+  rows so the dashboard can show "estimated, pre-2026-XX-XX".
+- `PriceService.getUsdPrice(...)` — instead of returning `0` on error,
+  throw `OracleUnavailableError`. Callers decide how to recover. PnL
+  callers catch + record a `priceUnavailable` flag in the breakdown.
+- Dashboard: add an explicit "X jobs have unresolved USD value"
+  warning banner so silent zeros become visible.
+
+---
+
+## 3. Acceptance criteria per phase
+
+### Phase 1
+- [ ] Job with reward + payment success → final status `COMPLETED`
+- [ ] Job with reward + payment failure → final status `PAYMENT_FAILED`
+      and reservation refunded via `releaseJobEscrow`
+- [ ] Job without reward → still completes synchronously (no behavior
+      change for free jobs)
+- [ ] Provider reputation only increments on actual `COMPLETED`
+- [ ] PnL queries (`status: 'COMPLETED'` filter) automatically exclude
+      ghost rows — no PnL code changes needed in this phase
+- [ ] `npm run typecheck --workspaces --if-present` passes
+- [ ] Backend tests pass (existing) + new unit test for the
+      ACCEPTED→PAYMENT_PENDING→COMPLETED path
+
+### Phase 2
+- [ ] Migration `0009` ships, applied cleanly to a fresh dev DB
+- [ ] New paid job: `rewardUsd` populated within X seconds of `COMPLETED`
+- [ ] Operator can disable price-blocking via env var
+
+### Phase 3
+- [ ] Dashboard shows count of jobs with `rewardUsd = NULL`
+- [ ] Snapshot used when available; live price only as fallback for
+      pre-Phase-2 rows
+- [ ] No code path returns `0` silently — every zero must be either a
+      real recorded value or accompanied by `priceUnavailable: true`
+
+---
+
+## 4. Follow-up tickets to file
+
+These came out of the investigation but are scope creep for the
+3-phase plan. File as separate issues *after* Phase 1 ships.
+
+1. **Stale `PAYMENT_PENDING` recovery worker** — BullMQ job that scans
+   every N minutes for jobs stuck in `PAYMENT_PENDING` longer than
+   the chain's typical confirmation window, re-checks tx receipt,
+   transitions to `COMPLETED` or `PAYMENT_FAILED` accordingly. Critical
+   for production safety.
+2. **`executeA2APayment` idempotency** — current implementation
+   re-broadcasts on retry, which can double-spend. Needs a
+   `txIntentId` keyed at the call site so retries collapse.
+3. **Admin dashboard: payment status filter + reconcile UI** — surface
+   `PAYMENT_PENDING` / `PAYMENT_FAILED` as first-class queues with a
+   "force complete" / "force fail" override for operators.
+
+---
+
+## 5. Status
+
+| Phase | Status     | PR  | Notes |
+| ----- | ---------- | --- | ----- |
+| 1     | in progress | TBD | branch `fix/a2a-revenue-integrity` |
+| 2     | not started | —   | depends on Phase 1 schema being merged |
+| 3     | not started | —   | depends on Phase 2 snapshot fields |

--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import type { JobStatus } from '@prisma/client';
 import { z } from 'zod';
 import { db } from '../../db/client.js';
 import { logger } from '../middleware/logger.js';
@@ -156,56 +157,111 @@ export async function jobRoutes(fastify: FastifyInstance) {
       });
     }
 
+    // Issue #71 — A2A revenue integrity (see docs/project/issue-71-a2a-revenue-integrity.md).
+    // For paid completions we no longer flip straight to COMPLETED. We move to
+    // PAYMENT_PENDING, fire the on-chain transfer, and only finalize as COMPLETED
+    // (with reputation + escrow release) when the transfer confirms. This keeps
+    // ghost completions out of the PnL dashboard.
+    const reward =
+      job.reward as { amount?: string; token?: string; chainId?: number } | null;
+    const isPaidCompletion = body.status === 'COMPLETED' && Boolean(reward?.amount);
+
+    const persistedStatus: JobStatus = isPaidCompletion ? 'PAYMENT_PENDING' : body.status;
+
     const updatedJob = await db.job.update({
       where: { id: request.params.id },
       data: {
-        status: body.status,
+        status: persistedStatus,
         ...(body.result !== undefined ? { result: body.result } : {}),
       },
     });
 
-    // Logic Sentinel: Automatically update reputation on outcome
-    if (body.status === 'COMPLETED') {
-      await reputationService.recordJobOutcome(job.providerId, true);
-
-      // v2 Escrow: mark reservation as released (consumed by payment).
-      // DailyVolume was already committed at reservation time, so we don't
-      // double-count. The payment execution re-checks policy anyway.
-      if (job.reservationStatus === 'PENDING') {
-        await markEscrowReleased(job.id);
+    if (isPaidCompletion) {
+      // Two-phase completion: side effects (reputation, escrow release, final
+      // COMPLETED status) only run inside the payment promise's resolution
+      // handlers, never before the on-chain transfer is settled.
+      const provider = await db.agent.findUnique({
+        where: { id: job.providerId },
+        select: { safeAddress: true },
+      });
+      if (!provider) {
+        // Defensive: provider record vanished between job creation and completion.
+        // Refund the requester and bail without firing payment.
+        await db.job.update({
+          where: { id: job.id },
+          data: { status: 'PAYMENT_FAILED' },
+        });
+        if (job.reservationStatus === 'PENDING') {
+          await releaseJobEscrow(job.id);
+        }
+        logger.error(
+          { jobId: job.id, providerId: job.providerId },
+          'A2A payment skipped — provider record missing; job marked PAYMENT_FAILED',
+        );
+        return reply.code(409).send({ error: 'Provider record missing; payment aborted' });
       }
 
-      // A2A Payment: if reward was specified, trigger atomic payment from
-      // requester to provider. Runs async — payment failures don't block
-      // the job status update, but are logged for operator review.
-      const reward = job.reward as { amount?: string; token?: string; chainId?: number } | null;
-      if (reward && reward.amount) {
-        const provider = await db.agent.findUnique({
-          where: { id: job.providerId },
-          select: { safeAddress: true },
-        });
-        if (provider) {
-          executeA2APayment({
-            requesterId: job.requesterId,
-            providerSafeAddress: provider.safeAddress,
-            amount: reward.amount,
-            token: reward.token ?? 'ETH',
-            chainId: reward.chainId ?? 1,
-            jobId: job.id,
-          })
-            .then((result) => {
-              logger.info(
-                { jobId: job.id, paymentTxId: result.transactionId },
-                'A2A payment triggered',
-              );
-            })
-            .catch((err) => {
-              logger.error(
-                { jobId: job.id, err: err?.message ?? String(err) },
-                'A2A payment failed — manual resolution required (escrow already released)',
-              );
+      // Capture reward fields locally; reward is non-null here (isPaidCompletion).
+      const amount = reward!.amount as string;
+      const token = reward!.token ?? 'ETH';
+      const chainId = reward!.chainId ?? 1;
+
+      executeA2APayment({
+        requesterId: job.requesterId,
+        providerSafeAddress: provider.safeAddress,
+        amount,
+        token,
+        chainId,
+        jobId: job.id,
+      })
+        .then(async (result) => {
+          // Payment confirmed → finalize: COMPLETED + reputation + escrow released.
+          await db.job.update({
+            where: { id: job.id },
+            data: { status: 'COMPLETED' },
+          });
+          await reputationService.recordJobOutcome(job.providerId, true);
+          if (job.reservationStatus === 'PENDING') {
+            await markEscrowReleased(job.id);
+          }
+          logger.info(
+            { jobId: job.id, paymentTxId: result.transactionId },
+            'A2A payment confirmed → COMPLETED',
+          );
+        })
+        .catch(async (err) => {
+          // Payment failed → mark PAYMENT_FAILED + refund escrow to requester.
+          // No reputation update: provider does not get credit for an unpaid job.
+          try {
+            await db.job.update({
+              where: { id: job.id },
+              data: { status: 'PAYMENT_FAILED' },
             });
-        }
+            if (job.reservationStatus === 'PENDING') {
+              await releaseJobEscrow(job.id);
+            }
+          } catch (recoveryErr) {
+            logger.error(
+              {
+                jobId: job.id,
+                paymentErr: err?.message ?? String(err),
+                recoveryErr:
+                  (recoveryErr as Error)?.message ?? String(recoveryErr),
+              },
+              'A2A payment failed AND status/escrow recovery failed — manual reconciliation required',
+            );
+            return;
+          }
+          logger.error(
+            { jobId: job.id, err: err?.message ?? String(err) },
+            'A2A payment failed → PAYMENT_FAILED, escrow refunded',
+          );
+        });
+    } else if (body.status === 'COMPLETED') {
+      // Free job (no reward) — completes synchronously, same as before.
+      await reputationService.recordJobOutcome(job.providerId, true);
+      if (job.reservationStatus === 'PENDING') {
+        await markEscrowReleased(job.id);
       }
     } else if (body.status === 'FAILED' || body.status === 'CANCELLED') {
       // v2 Escrow: release reservation, return daily volume credit to requester
@@ -217,7 +273,7 @@ export async function jobRoutes(fastify: FastifyInstance) {
       }
     }
 
-    logger.info({ jobId: job.id, status: body.status }, 'A2A Job Updated');
+    logger.info({ jobId: job.id, status: persistedStatus }, 'A2A Job Updated');
     return updatedJob;
   });
 

--- a/packages/backend/src/db/migrations/0008_job_payment_status/migration.sql
+++ b/packages/backend/src/db/migrations/0008_job_payment_status/migration.sql
@@ -1,0 +1,20 @@
+-- Migration: 0008_job_payment_status
+-- Purpose: Add intermediate payment lifecycle states to JobStatus so the
+--          PATCH /v1/jobs/:id handler stops reporting revenue for jobs
+--          whose on-chain payment has not yet confirmed (or failed).
+--
+--          PAYMENT_PENDING: provider marked work done, payment fired but
+--          not yet confirmed on-chain. Revenue must NOT be counted here.
+--
+--          PAYMENT_FAILED: payment broadcast failed (or reverted) after
+--          provider marked the work done. Escrow is refunded to requester.
+--
+-- Notes:
+--   * Postgres requires `ALTER TYPE ... ADD VALUE` to run outside an
+--     explicit transaction in older server versions; Prisma's migrate
+--     deploy runs each statement separately, so we keep them as two
+--     standalone statements with IF NOT EXISTS for idempotency.
+--   * Existing rows are unaffected — old jobs keep their COMPLETED status.
+
+ALTER TYPE "JobStatus" ADD VALUE IF NOT EXISTS 'PAYMENT_PENDING';
+ALTER TYPE "JobStatus" ADD VALUE IF NOT EXISTS 'PAYMENT_FAILED';

--- a/packages/backend/src/db/schema.prisma
+++ b/packages/backend/src/db/schema.prisma
@@ -79,6 +79,8 @@ enum JobStatus {
   COMPLETED
   FAILED
   CANCELLED
+  PAYMENT_PENDING  // Provider marked work done; on-chain payment in flight. Not counted as revenue.
+  PAYMENT_FAILED   // Payment broadcast failed/reverted; escrow refunded to requester.
 }
 
 // Subscription tiers — drives rate limits and fee rates


### PR DESCRIPTION
Closes Phase 1 of #71. Full plan: [docs/project/issue-71-a2a-revenue-integrity.md](https://github.com/felippeyann/agentfi/blob/fix/a2a-revenue-integrity/docs/project/issue-71-a2a-revenue-integrity.md).

## Summary

Paid A2A jobs no longer report revenue for failed payments. Provider's `PATCH /v1/jobs/:id` to `COMPLETED` now moves rewarded jobs to a new `PAYMENT_PENDING` state; the job only finalizes as `COMPLETED` (with reputation credit + escrow release) when the on-chain transfer confirms. On payment failure → `PAYMENT_FAILED` and escrow refunded to the requester.

Free jobs (no reward) still complete synchronously — no behavior change.

## What changed

- **Schema:** `PAYMENT_PENDING`, `PAYMENT_FAILED` added to `JobStatus` enum.
- **Migration:** `0008_job_payment_status/migration.sql` (idempotent `ALTER TYPE`).
- **Route refactor:** `packages/backend/src/api/routes/jobs.ts` — side effects (`recordJobOutcome`, `markEscrowReleased`) moved into the payment promise's `.then`. `releaseJobEscrow` added to the `.catch` so failed payments refund the requester.
- **API contract unchanged:** `VALID_TRANSITIONS` still exposes only `COMPLETED`/`FAILED`/`CANCELLED` to clients. New states are system-only.

## Why two-phase status instead of synchronous `await`?

Blocking the HTTP response on on-chain confirmation (10–30+ s, longer on gas spikes) breaks SDK clients with default timeouts and ties up Fastify worker threads. The async-with-state-machine pattern is the standard Web3 fix and matches the rest of the codebase. Rationale documented in the plan doc §2.

## Knock-on benefit

PnL and reputation queries already filter by `status='COMPLETED'`, so they automatically exclude `PAYMENT_PENDING` rows — Phase 1 fixes the dashboard ghost-revenue bug with zero downstream changes needed.

## Known gaps (filed as follow-ups in the plan doc §4)

- Server crash between `PAYMENT_PENDING` and the `.then` resolving leaves the job stuck. Needs a BullMQ recovery worker scanning for stale rows.
- `executeA2APayment` is not yet idempotent under retry — could double-spend on naive replay.
- Admin dashboard has no `PAYMENT_PENDING` / `PAYMENT_FAILED` filter yet.

Phases 2 (revenue snapshots) and 3 (PnL refactor) are independent PRs.

## Test plan

- [x] `npm run typecheck --workspaces --if-present` — passes
- [x] Backend unit tests — 78/82 pass locally; the 4 failing are pre-existing integration tests in `agent.search.test.ts` that need a live Postgres
- [ ] CI: backend + e2e green
- [ ] Manual: paid job → payment success → status `COMPLETED`, reputation +1, escrow `RELEASED`
- [ ] Manual: paid job → payment failure → status `PAYMENT_FAILED`, reputation unchanged, escrow refunded
- [ ] Manual: free job → status `COMPLETED` synchronously (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)