### PR TITLE
feat(backend): operator notifications on A2A payment success and failure

### DIFF
--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -10,6 +10,7 @@ import {
   releaseJobEscrow,
   markEscrowReleased,
 } from '../../services/policy/escrow.service.js';
+import { notificationService } from '../../services/notification.service.js';
 const reputationService = new ReputationService();
 
 const createJobSchema = z.object({
@@ -182,7 +183,7 @@ export async function jobRoutes(fastify: FastifyInstance) {
       // handlers, never before the on-chain transfer is settled.
       const provider = await db.agent.findUnique({
         where: { id: job.providerId },
-        select: { safeAddress: true },
+        select: { safeAddress: true, name: true },
       });
       if (!provider) {
         // Defensive: provider record vanished between job creation and completion.
@@ -228,6 +229,29 @@ export async function jobRoutes(fastify: FastifyInstance) {
             { jobId: job.id, paymentTxId: result.transactionId },
             'A2A payment confirmed → COMPLETED',
           );
+          // Operator notification (Discord/Telegram/webhook fan-out is non-fatal).
+          notificationService
+            .notify({
+              type: 'TRANSACTION_CONFIRMED',
+              agentId: job.providerId,
+              agentName: provider.name,
+              transactionId: result.transactionId,
+              message: `A2A payment settled: ${amount} ${token} (chain ${chainId}) for job ${job.id}`,
+              metadata: {
+                jobId: job.id,
+                requesterId: job.requesterId,
+                providerId: job.providerId,
+                amount,
+                token,
+                chainId,
+              },
+            })
+            .catch((notifyErr) =>
+              logger.warn(
+                { jobId: job.id, err: (notifyErr as Error)?.message ?? String(notifyErr) },
+                'A2A payment success notification failed (non-fatal)',
+              ),
+            );
         })
         .catch(async (err) => {
           // Payment failed → mark PAYMENT_FAILED + refund escrow to requester.
@@ -256,6 +280,29 @@ export async function jobRoutes(fastify: FastifyInstance) {
             { jobId: job.id, err: err?.message ?? String(err) },
             'A2A payment failed → PAYMENT_FAILED, escrow refunded',
           );
+          // Operator notification — critical, but still non-fatal if delivery fails.
+          notificationService
+            .notify({
+              type: 'TRANSACTION_FAILED',
+              agentId: job.providerId,
+              agentName: provider.name,
+              message: `A2A payment FAILED: ${amount} ${token} (chain ${chainId}) for job ${job.id}. Escrow refunded to requester. Reason: ${err?.message ?? String(err)}`,
+              metadata: {
+                jobId: job.id,
+                requesterId: job.requesterId,
+                providerId: job.providerId,
+                amount,
+                token,
+                chainId,
+                error: err?.message ?? String(err),
+              },
+            })
+            .catch((notifyErr) =>
+              logger.warn(
+                { jobId: job.id, err: (notifyErr as Error)?.message ?? String(notifyErr) },
+                'A2A payment failure notification failed (non-fatal) — operator may miss this event',
+              ),
+            );
         });
     } else if (body.status === 'COMPLETED') {
       // Free job (no reward) — completes synchronously, same as before.


### PR DESCRIPTION
## Summary

Wires \`NotificationService\` into the two-phase payment flow from #72 so operators get Discord/Telegram/webhook notifications for every paid A2A job that settles or fails on-chain.

Closes a monitoring gap surfaced right after #72 shipped: previously the only signal of \`PAYMENT_FAILED\` was a \`logger.error\` line that nobody watches by default.

## What changed

[\`packages/backend/src/api/routes/jobs.ts\`](packages/backend/src/api/routes/jobs.ts):
- Inside the payment promise's \`.then\` (success) → \`notify({ type: 'TRANSACTION_CONFIRMED', ... })\`
- Inside the payment promise's \`.catch\` (failure) → \`notify({ type: 'TRANSACTION_FAILED', ... })\`
- Provider lookup now also selects \`name\` (needed by NotificationPayload)
- Both notify calls are fire-and-forget with a \`.catch\` logging non-fatally — a notification delivery failure must never block or roll back a settled payment

## Mapping decision

Reused existing \`NotificationPayload\` types instead of extending the union:
- payment success → \`TRANSACTION_CONFIRMED\` (✅)
- payment failure → \`TRANSACTION_FAILED\` (❌)

A2A-specific context (jobId, requesterId, providerId, amount, token, chainId, error) goes in \`message\` and \`metadata\`. Smaller PR, no schema/type ripple.

## What this does NOT do (still in the follow-up tickets)

- Doesn't fire when a job gets stuck in \`PAYMENT_PENDING\` (no recovery worker yet — see #73)
- Doesn't surface in admin dashboard (see #75)
- Doesn't address historical revenue snapshots (Phase 2 of #71)

## Test plan

- [x] \`npm run typecheck --workspaces --if-present\` — passes
- [ ] CI: backend + lint + e2e green
- [ ] Manual: configure \`OPERATOR_DISCORD_WEBHOOK\` (or Telegram), trigger a paid A2A job, confirm Discord embed arrives on success
- [ ] Manual: trigger a payment that will fail (e.g. requester out of funds), confirm Discord embed arrives on failure with the reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)