### PR TITLE
fix(backend): notification delivery visibility + finalizer write ordering

### DIFF
--- a/packages/backend/src/services/job/payment-finalizer.service.ts
+++ b/packages/backend/src/services/job/payment-finalizer.service.ts
@@ -85,14 +85,18 @@ export async function finalizeA2APaymentJob(
   const providerName = job.provider?.name ?? job.providerId;
 
   if (outcome === 'CONFIRMED') {
+    // Order matters (mirrors the FAILED branch below): perform side effects
+    // first, flip the public Job status last. An observer polling between
+    // writes sees either old (PAYMENT_PENDING + PENDING) or new
+    // (COMPLETED + RELEASED) state — never an inconsistent intermediate.
+    if (job.reservationStatus === 'PENDING') {
+      await markEscrowReleased(jobId);
+    }
+    await reputationService.recordJobOutcome(job.providerId, true);
     await db.job.update({
       where: { id: jobId },
       data: { status: 'COMPLETED' },
     });
-    await reputationService.recordJobOutcome(job.providerId, true);
-    if (job.reservationStatus === 'PENDING') {
-      await markEscrowReleased(jobId);
-    }
     logger.info(
       { jobId, transactionId },
       'A2A finalizer: payment confirmed → COMPLETED',
@@ -124,14 +128,23 @@ export async function finalizeA2APaymentJob(
   }
 
   // outcome === 'FAILED'
+  // Order matters: refund the escrow FIRST, then flip the Job status. The
+  // Job status (`PAYMENT_FAILED`) is the public signal everyone polls on
+  // (admin dashboard, requester UI, automated tests). If we flipped status
+  // first and then refunded, an observer polling between the two writes
+  // would see `PAYMENT_FAILED` + `reservationStatus: PENDING` — which is
+  // exactly the "ghost completion" symptom #81 was meant to eliminate.
+  // By doing the refund first, any in-flight observer either sees the old
+  // (`PAYMENT_PENDING` + `PENDING`) or the new (`PAYMENT_FAILED` + `CANCELLED`)
+  // state — never an inconsistent intermediate.
   try {
+    if (job.reservationStatus === 'PENDING') {
+      await releaseJobEscrow(jobId);
+    }
     await db.job.update({
       where: { id: jobId },
       data: { status: 'PAYMENT_FAILED' },
     });
-    if (job.reservationStatus === 'PENDING') {
-      await releaseJobEscrow(jobId);
-    }
   } catch (recoveryErr) {
     logger.error(
       {

--- a/packages/backend/src/services/notification.service.ts
+++ b/packages/backend/src/services/notification.service.ts
@@ -18,26 +18,71 @@ const TYPE_EMOJI: Record<NotificationPayload['type'], string> = {
   POLICY_VIOLATION:      '⛔',
 };
 
-function formatText(payload: NotificationPayload): string {
+/**
+ * Escape user-controlled text for Telegram HTML parse mode.
+ *
+ * We use HTML rather than legacy Markdown because Markdown silently corrupts on
+ * any unmatched `_`, `*`, or `` ` `` in dynamic content (e.g. an error message
+ * containing `eth_estimateGas` or contract addresses). HTML mode only requires
+ * escaping three characters and never silently swallows formatting.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function formatTelegramHtml(payload: NotificationPayload): string {
   const { type, agentName, message, transactionId } = payload;
   const emoji = TYPE_EMOJI[type];
   const lines = [
-    `${emoji} *${type}*`,
-    `Agent: ${agentName}`,
-    message,
+    `${emoji} <b>${escapeHtml(type)}</b>`,
+    `Agent: ${escapeHtml(agentName)}`,
+    escapeHtml(message),
   ];
-  if (transactionId) lines.push(`Tx: \`${transactionId}\``);
+  if (transactionId) lines.push(`Tx: <code>${escapeHtml(transactionId)}</code>`);
   return lines.join('\n');
 }
 
 // ─── Adapters ─────────────────────────────────────────────────────────────────
 
+/**
+ * Throws on non-2xx responses so the caller's `.catch` fires and produces a
+ * loud `Failed to send …` log line. Without this guard, a 4xx silently
+ * resolves the fetch and the operator never learns delivery broke — which is
+ * exactly how the empty-env-var Telegram outage in #84 follow-up went
+ * undetected for hours.
+ */
+async function fetchAndAssertOk(
+  url: string,
+  init: RequestInit,
+  channel: string,
+): Promise<void> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = (await res.text()).slice(0, 500);
+    } catch {
+      // If we can't even read the body, the status alone is enough signal.
+    }
+    throw new Error(
+      `${channel} delivery failed: HTTP ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`,
+    );
+  }
+}
+
 async function sendGenericWebhook(url: string, payload: NotificationPayload): Promise<void> {
-  await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
+  await fetchAndAssertOk(
+    url,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+    'generic webhook',
+  );
 }
 
 async function sendDiscord(webhookUrl: string, payload: NotificationPayload): Promise<void> {
@@ -49,22 +94,26 @@ async function sendDiscord(webhookUrl: string, payload: NotificationPayload): Pr
   ];
   if (transactionId) fields.push({ name: 'Transaction', value: transactionId, inline: false });
 
-  await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      embeds: [{
-        title: `${emoji} ${type}`,
-        description: message,
-        color: type === 'PENDING_APPROVAL' ? 0xF59E0B
-          : type === 'TRANSACTION_CONFIRMED' ? 0x22C55E
-          : type === 'POLICY_VIOLATION' ? 0xEF4444
-          : 0x6B7280,
-        fields,
-        timestamp: new Date().toISOString(),
-      }],
-    }),
-  });
+  await fetchAndAssertOk(
+    webhookUrl,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [{
+          title: `${emoji} ${type}`,
+          description: message,
+          color: type === 'PENDING_APPROVAL' ? 0xF59E0B
+            : type === 'TRANSACTION_CONFIRMED' ? 0x22C55E
+            : type === 'POLICY_VIOLATION' ? 0xEF4444
+            : 0x6B7280,
+          fields,
+          timestamp: new Date().toISOString(),
+        }],
+      }),
+    },
+    'Discord',
+  );
 }
 
 async function sendTelegram(
@@ -72,16 +121,20 @@ async function sendTelegram(
   chatId: string,
   payload: NotificationPayload,
 ): Promise<void> {
-  const text = formatText(payload);
-  await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      chat_id: chatId,
-      text,
-      parse_mode: 'Markdown',
-    }),
-  });
+  const text = formatTelegramHtml(payload);
+  await fetchAndAssertOk(
+    `https://api.telegram.org/bot${botToken}/sendMessage`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: 'HTML',
+      }),
+    },
+    'Telegram',
+  );
 }
 
 // ─── Service ──────────────────────────────────────────────────────────────────
@@ -104,36 +157,65 @@ export class NotificationService {
       console.log('='.repeat(50) + '\n');
     }
 
-    // 3. External channels — all fire in parallel, failures are non-fatal
+    // 3. External channels — all fire in parallel, failures are non-fatal but
+    // ALWAYS logged. Channels with no config (env var unset) are visibly
+    // skipped at debug level so an operator can spot a misconfigured machine
+    // (env var dropped during a rolling restart, secret never propagated, etc.)
+    // by the absence of dispatch logs after a `[Notification]` event.
     const dispatches: Promise<void>[] = [];
+    const enabledChannels: string[] = [];
+    const skippedChannels: string[] = [];
 
     const webhookUrl = process.env['OPERATOR_NOTIFICATION_WEBHOOK'];
     if (webhookUrl) {
+      enabledChannels.push('webhook');
       dispatches.push(
         sendGenericWebhook(webhookUrl, payload).catch((err) =>
-          logger.warn({ err }, 'Failed to send generic webhook notification'),
+          logger.warn(
+            { err: (err as Error)?.message ?? String(err), channel: 'webhook', type },
+            'Failed to send generic webhook notification',
+          ),
         ),
       );
+    } else {
+      skippedChannels.push('webhook');
     }
 
     const discordUrl = process.env['OPERATOR_DISCORD_WEBHOOK'];
     if (discordUrl) {
+      enabledChannels.push('discord');
       dispatches.push(
         sendDiscord(discordUrl, payload).catch((err) =>
-          logger.warn({ err }, 'Failed to send Discord notification'),
+          logger.warn(
+            { err: (err as Error)?.message ?? String(err), channel: 'discord', type },
+            'Failed to send Discord notification',
+          ),
         ),
       );
+    } else {
+      skippedChannels.push('discord');
     }
 
     const telegramToken = process.env['OPERATOR_TELEGRAM_BOT_TOKEN'];
     const telegramChatId = process.env['OPERATOR_TELEGRAM_CHAT_ID'];
     if (telegramToken && telegramChatId) {
+      enabledChannels.push('telegram');
       dispatches.push(
         sendTelegram(telegramToken, telegramChatId, payload).catch((err) =>
-          logger.warn({ err }, 'Failed to send Telegram notification'),
+          logger.warn(
+            { err: (err as Error)?.message ?? String(err), channel: 'telegram', type },
+            'Failed to send Telegram notification',
+          ),
         ),
       );
+    } else {
+      skippedChannels.push('telegram');
     }
+
+    logger.debug(
+      { type, enabled: enabledChannels, skipped: skippedChannels },
+      'Notification channels resolved',
+    );
 
     await Promise.all(dispatches);
   }


### PR DESCRIPTION
## Summary

Two follow-up issues surfaced during the post-#83 E2E validation pass.

### 1. Silent notification failures

`sendTelegram` / `sendDiscord` / `sendGenericWebhook` only `await fetch(...)` — none check `res.ok`. A 4xx/5xx (or, as we hit in production, an empty bot token producing a 404 on the URL) silently resolves the fetch, the `.catch` wrapper in `notify()` never fires, no warn log lands, and the operator only learns delivery is broken by noticing missing messages downstream.

This is **exactly how the empty-env Telegram outage in production stayed undetected through two full E2E runs** — the assertion `Job → PAYMENT_FAILED + escrow refunded` passed, the operator never got a Telegram message, and we spent ~1h diagnosing because no log line said "delivery failed".

**Fix:** extract a shared `fetchAndAssertOk` helper that throws on non-2xx with the response body included. Now any HTTP-level failure produces a loud `Failed to send <channel> notification` log with the actual error message and status code.

Also:
- Added a `Notification channels resolved` **debug log** listing `{enabled, skipped}` channels per dispatch. Makes "env var unset" vs "delivery failed" trivially distinguishable from a single grep.
- Switched **Telegram from `parse_mode=Markdown` to `parse_mode=HTML`** with proper entity escaping. Markdown silently corrupts on any unmatched `_`, `*`, or `` ` `` in dynamic content (`eth_estimateGas` in an error message, contract addresses like `0xae6d…_…`, etc.); HTML mode only needs `&<>` escaped and never silently drops formatting.

### 2. Finalizer write ordering — surfaced by E2E run #2

`payment-finalizer.service.ts` flipped the public Job status (`COMPLETED` / `PAYMENT_FAILED`) **before** writing the side effects (escrow refund/release, reputation). An observer polling between the two writes saw e.g. `status=PAYMENT_FAILED` + `reservationStatus=PENDING` — exactly the "ghost completion" intermediate state that #81 was meant to eliminate. Surfaced live in the second post-#83 E2E run.

**Fix:** perform side effects first, flip status last on **both** branches (`CONFIRMED` and `FAILED`). An observer now only ever sees old (`PAYMENT_PENDING` + `PENDING`) or new (`COMPLETED + RELEASED` / `PAYMENT_FAILED + CANCELLED`) consistent state, never an inconsistent intermediate.

## Test plan

- [x] `npm run typecheck --workspaces --if-present` — green across all 4 workspaces
- [ ] Re-run [scripts/e2e-issue-81.mjs](scripts/e2e-issue-81.mjs) on Fly:
  - Assertion (`PAYMENT_FAILED + CANCELLED`) should pass deterministically — race window collapsed
  - Telegram channel should receive a `❌ TRANSACTION_FAILED` message with HTML-formatted bold + code blocks
  - If env var is missing or token revoked, Fly logs should now contain a `Failed to send Telegram notification` warn line with the HTTP status — instead of total silence

## Notes

- No DB schema changes.
- Backwards-compatible at the API surface — only internal write ordering and notify error-handling changed.
- The Vercel `agentfi-admin` preview check is the standing flake from HANDOFF §7, not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)