### PR TITLE
feat(backend): payment recovery worker for stale PAYMENT_PENDING jobs (#73)

### DIFF
--- a/docs/project/issue-71-a2a-revenue-integrity.md
+++ b/docs/project/issue-71-a2a-revenue-integrity.md
@@ -284,6 +284,8 @@ These came out of the investigation but are scope creep for the
 | ----- | ----------- | --- | ----- |
 | 1     | shipped     | #72 | branch `fix/a2a-revenue-integrity` (merged) |
 | 1.5   | shipped     | #83 | branch `fix/issue-81-payment-lifecycle` (merged) — closed #81 |
-| #74   | in progress | TBD | branch `fix/issue-74-tx-idempotency` — adds `Transaction.intentId` for safe retry |
+| #74   | shipped     | #84 | branch `fix/issue-74-tx-idempotency` (merged) — `Transaction.intentId` |
+| #85   | shipped     | #85 | branch `fix/notification-visibility-and-finalizer-order` (merged) — surfaces silent notify failures + fixes finalizer write race |
+| #73   | in progress | TBD | branch `fix/issue-73-payment-recovery-worker` — BullMQ scan reconciles stale `PAYMENT_PENDING` |
 | 2     | not started | —   | depends on Phase 1 schema being merged |
 | 3     | not started | —   | depends on Phase 2 snapshot fields |

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -15,6 +15,10 @@ import { mcpRoutes } from './api/routes/mcp.js';
 import { jobRoutes } from './api/routes/jobs.js';
 import { startTransactionWorker } from './queues/transaction.queue.js';
 import { startReputationWorker, scheduleReputationUpdate } from './queues/reputation.queue.js';
+import {
+  startPaymentRecoveryWorker,
+  schedulePaymentRecovery,
+} from './queues/payment-recovery.queue.js';
 
 // Fastify v5 expects a logger CONFIG object (not a pino instance). We pass
 // the same options that middleware/logger.ts uses for its standalone export,
@@ -129,11 +133,29 @@ async function start() {
     logger.error({ err }, 'Reputation worker failed to start');
   }
 
+  // Payment recovery cron worker (#73). Tied to TRANSACTION_WORKER_ENABLED
+  // because there's no point running recovery on a replica that doesn't also
+  // process transactions — both feed off the same Job/Transaction tables and
+  // the recovery logic is harmless to run on multiple replicas (idempotent),
+  // but pointless on replicas where the transaction worker is disabled.
+  let paymentRecoveryWorker:
+    | ReturnType<typeof startPaymentRecoveryWorker>
+    | undefined;
+  if (env.TRANSACTION_WORKER_ENABLED === 'true') {
+    try {
+      paymentRecoveryWorker = startPaymentRecoveryWorker();
+      await schedulePaymentRecovery();
+    } catch (err) {
+      logger.error({ err }, 'Payment recovery worker failed to start');
+    }
+  }
+
   // Graceful shutdown
   const shutdown = async () => {
     logger.info('Shutting down...');
     if (worker) await worker.close();
     if (reputationWorker) await reputationWorker.close();
+    if (paymentRecoveryWorker) await paymentRecoveryWorker.close();
     await fastify.close();
     process.exit(0);
   };

--- a/packages/backend/src/queues/payment-recovery.queue.ts
+++ b/packages/backend/src/queues/payment-recovery.queue.ts
@@ -1,0 +1,220 @@
+/**
+ * Payment Recovery Queue — BullMQ repeatable job for stale PAYMENT_PENDING jobs.
+ *
+ * Issue #73 (Phase 1.5 of #71). Without this, a backend crash between the
+ * `executeA2APayment` call and the worker confirming the on-chain outcome
+ * leaves the Job stuck in `PAYMENT_PENDING` forever. Provider work is done,
+ * requester escrow is locked, the dashboard hides the row from PnL → silent
+ * production-grade data integrity failure.
+ *
+ * Architecture (deliberately simple, leaning on prior work):
+ *   1. Every N minutes, scan Job rows with `status = 'PAYMENT_PENDING'` AND
+ *      `updatedAt < now() - STALE_THRESHOLD`.
+ *   2. For each candidate, look up the Transaction via the deterministic
+ *      `intentId = "a2a-payment:<jobId>"` introduced by #74. One indexed row.
+ *   3. Decide based on the Transaction's on-chain status:
+ *        - CONFIRMED  → call finalizer(CONFIRMED) — worker crashed before
+ *                       triggering the finalizer; complete the lifecycle now.
+ *        - REVERTED / FAILED → finalizer(FAILED) — refund escrow, mark job.
+ *        - QUEUED / SUBMITTED / PENDING_APPROVAL → leave alone (still in-flight,
+ *          BullMQ will retry / human will approve).
+ *        - No Transaction at all → orphan. Refund as PAYMENT_FAILED with reason.
+ *
+ *  Idempotency rests on three pillars from prior PRs:
+ *    - #74: intentId on Transaction prevents duplicate broadcasts on retry.
+ *    - #83: finalizer no-ops when Job is not in PAYMENT_PENDING.
+ *    - #85: refund-then-flip ordering means observers never see a partial state.
+ */
+
+import { Queue, Worker } from 'bullmq';
+import { db } from '../db/client.js';
+import { env } from '../config/env.js';
+import { logger } from '../api/middleware/logger.js';
+import { finalizeA2APaymentJob } from '../services/job/payment-finalizer.service.js';
+
+const RECOVERY_QUEUE_NAME = 'payment-recovery';
+
+// How often the recovery scan runs. 2 minutes by default — tight enough that a
+// stuck job is recovered quickly, loose enough to keep Redis polling cheap.
+const RECOVERY_INTERVAL_MS =
+  parseInt(process.env['PAYMENT_RECOVERY_INTERVAL_SEC'] ?? '120', 10) * 1000;
+
+// How long a Job must sit in PAYMENT_PENDING before the recovery worker
+// considers it stale. Default 5 min — covers BullMQ's 3-attempt retry window
+// (≈35s with our exponential backoff) plus a comfortable buffer for slow
+// chains and price-oracle latency. Bump higher on chains with longer
+// confirmation windows; lower on testnets.
+const STALE_THRESHOLD_MS =
+  parseInt(process.env['PAYMENT_RECOVERY_STALE_THRESHOLD_SEC'] ?? '300', 10) * 1000;
+
+// Cap per scan tick — protects against unbounded queries if the table ever
+// accumulates a large backlog (e.g. after a multi-hour outage).
+const PER_TICK_LIMIT = parseInt(process.env['PAYMENT_RECOVERY_PER_TICK_LIMIT'] ?? '50', 10);
+
+const connection = {
+  url: env.REDIS_URL,
+  maxRetriesPerRequest: null as unknown as number,
+  enableReadyCheck: false,
+};
+
+export const paymentRecoveryQueue = new Queue(RECOVERY_QUEUE_NAME, {
+  connection,
+  defaultJobOptions: {
+    attempts: 2,
+    backoff: { type: 'exponential', delay: 30_000 },
+    // Keep the last few completed/failed scans visible for debugging without
+    // accumulating forever.
+    removeOnComplete: { count: 50 },
+    removeOnFail: { count: 100 },
+  },
+});
+
+/**
+ * Idempotently registers the repeatable scan job. BullMQ dedupes by jobId, so
+ * calling this on every boot is safe — only the first call (across all
+ * replicas) creates the schedule; subsequent calls are no-ops.
+ */
+export async function schedulePaymentRecovery(): Promise<void> {
+  await paymentRecoveryQueue.add(
+    'scan',
+    {},
+    {
+      repeat: { every: RECOVERY_INTERVAL_MS },
+      jobId: 'payment-recovery-scan', // prevents duplicates across restarts/replicas
+    },
+  );
+  logger.info(
+    {
+      queue: RECOVERY_QUEUE_NAME,
+      intervalMs: RECOVERY_INTERVAL_MS,
+      staleThresholdMs: STALE_THRESHOLD_MS,
+      perTickLimit: PER_TICK_LIMIT,
+    },
+    'Payment recovery scan scheduled',
+  );
+}
+
+interface RecoverySummary {
+  scanned: number;
+  finalizedConfirmed: number;
+  finalizedFailed: number;
+  refundedOrphan: number;
+  stillInFlight: number;
+}
+
+export function startPaymentRecoveryWorker(): Worker {
+  const worker = new Worker(
+    RECOVERY_QUEUE_NAME,
+    async () => {
+      const cutoff = new Date(Date.now() - STALE_THRESHOLD_MS);
+
+      const stale = await db.job.findMany({
+        where: {
+          status: 'PAYMENT_PENDING',
+          updatedAt: { lt: cutoff },
+        },
+        select: { id: true, updatedAt: true },
+        take: PER_TICK_LIMIT,
+        orderBy: { updatedAt: 'asc' }, // oldest first, in case we hit the cap
+      });
+
+      const summary: RecoverySummary = {
+        scanned: stale.length,
+        finalizedConfirmed: 0,
+        finalizedFailed: 0,
+        refundedOrphan: 0,
+        stillInFlight: 0,
+      };
+
+      if (stale.length === 0) {
+        logger.debug(summary, 'Payment recovery scan: nothing to do');
+        return summary;
+      }
+
+      for (const job of stale) {
+        const intentId = `a2a-payment:${job.id}`;
+        const tx = await db.transaction.findUnique({
+          where: { intentId },
+          select: { id: true, status: true, error: true },
+        });
+
+        if (!tx) {
+          // Orphan: Job stuck in PAYMENT_PENDING with no Transaction row.
+          // executeA2APayment must have died before line 1848 of
+          // api/routes/transactions.ts (the create() call). Without a Tx
+          // there is nothing to recover from — refund the escrow.
+          logger.warn(
+            { jobId: job.id, ageSec: Math.floor((Date.now() - job.updatedAt.getTime()) / 1000) },
+            'Payment recovery: orphan PAYMENT_PENDING (no Transaction) → refunding',
+          );
+          await finalizeA2APaymentJob({
+            jobId: job.id,
+            transactionId: null,
+            outcome: 'FAILED',
+            reason: 'Recovery: orphan PAYMENT_PENDING with no Transaction record',
+          });
+          summary.refundedOrphan++;
+          continue;
+        }
+
+        if (tx.status === 'CONFIRMED') {
+          // Worker crashed between the chain confirmation and the finalizer
+          // call. Complete the lifecycle now.
+          logger.info(
+            { jobId: job.id, transactionId: tx.id },
+            'Payment recovery: tx CONFIRMED but Job still PAYMENT_PENDING → finalizing as COMPLETED',
+          );
+          await finalizeA2APaymentJob({
+            jobId: job.id,
+            transactionId: tx.id,
+            outcome: 'CONFIRMED',
+          });
+          summary.finalizedConfirmed++;
+          continue;
+        }
+
+        if (tx.status === 'REVERTED' || tx.status === 'FAILED') {
+          logger.info(
+            { jobId: job.id, transactionId: tx.id, txStatus: tx.status },
+            `Payment recovery: tx ${tx.status} but Job still PAYMENT_PENDING → finalizing as PAYMENT_FAILED`,
+          );
+          await finalizeA2APaymentJob({
+            jobId: job.id,
+            transactionId: tx.id,
+            outcome: 'FAILED',
+            reason: `Recovery: tx ${tx.status} (${tx.error ?? 'no error message recorded'})`,
+          });
+          summary.finalizedFailed++;
+          continue;
+        }
+
+        // QUEUED, SUBMITTED, PENDING_APPROVAL — still in-flight. The
+        // transaction worker (or human approver) will reach the finalizer
+        // through the normal path. Don't interfere; the next scan will pick
+        // it up if it stays stuck.
+        logger.debug(
+          { jobId: job.id, transactionId: tx.id, txStatus: tx.status },
+          'Payment recovery: tx still in-flight, leaving alone',
+        );
+        summary.stillInFlight++;
+      }
+
+      logger.info(summary, 'Payment recovery scan completed');
+      return summary;
+    },
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
+
+  worker.on('failed', (job, err) => {
+    logger.error(
+      { jobId: job?.id, err: err?.message ?? String(err) },
+      'Payment recovery scan failed',
+    );
+  });
+
+  logger.info({ queue: RECOVERY_QUEUE_NAME }, 'Payment recovery worker started');
+  return worker;
+}


### PR DESCRIPTION
## Summary

Closes #73. Last gap in #71's Phase 1.5 cleanup. Without this, a backend crash between `executeA2APayment` and worker confirmation orphans the Job in `PAYMENT_PENDING` forever — provider work done, requester escrow locked, dashboard hides the row from PnL → silent data integrity bug.

## Architecture (deliberately small — leans on prior PRs)

- **New queue** [queues/payment-recovery.queue.ts](packages/backend/src/queues/payment-recovery.queue.ts). BullMQ repeatable job `'payment-recovery-scan'`, every `PAYMENT_RECOVERY_INTERVAL_SEC` (default **120s**), scans `Job` rows where `status='PAYMENT_PENDING'` AND `updatedAt < now() - PAYMENT_RECOVERY_STALE_THRESHOLD_SEC` (default **300s**). Capped at `PAYMENT_RECOVERY_PER_TICK_LIMIT` rows (default **50**) so query cost stays bounded even after a long outage backlog.

- **For each stale job** → look up the Transaction via the deterministic `` intentId = `a2a-payment:${jobId}` `` (added in #84 — single indexed lookup). Decision on `tx.status`:

  | tx.status | action | reason |
  |---|---|---|
  | `CONFIRMED` | `finalizer(CONFIRMED)` | Worker crashed between confirmation and finalizer |
  | `REVERTED`, `FAILED` | `finalizer(FAILED)` | On-chain failure, refund escrow |
  | `QUEUED`, `SUBMITTED`, `PENDING_APPROVAL` | leave alone | Still in-flight, BullMQ retries / human approves |
  | _no tx found_ | `finalizer(FAILED, reason='orphan')` | `executeA2APayment` died before persisting Tx; refund |

- **Idempotency comes from prior work, not new logic:**
  - **#74** `intentId` UNIQUE: re-broadcasts short-circuit to existing tx
  - **#83** finalizer is a no-op when Job is not in `PAYMENT_PENDING`
  - **#85** finalizer write order (refund → flip status) means partial state isn't observable

- **Wiring**: started after the reputation worker in `index.ts`. Tied to `TRANSACTION_WORKER_ENABLED` (existing convention) so disabled replicas don't run it, and prod needs to opt in explicitly.

- **Observability**: per-job log lines describing the decision (with `jobId`, `transactionId`, `txStatus`), plus a structured summary `{scanned, finalizedConfirmed, finalizedFailed, refundedOrphan, stillInFlight}` on every tick. `grep "Payment recovery"` is sufficient for a postmortem.

## Test plan

- [x] `npm run typecheck --workspaces --if-present` — green across all 4 workspaces
- [ ] After deploy: confirm BullMQ schedules the repeating job:
  ```
  fly logs -a agentfi-backend | grep "Payment recovery scan scheduled"
  ```
- [ ] Crash-recovery synthetic test (manual):
  1. PATCH a Job to `COMPLETED` with reward (paid path)
  2. Backend immediately sets Job to `PAYMENT_PENDING` and queues the tx
  3. Restart the machine before BullMQ finishes processing (`flyctl machine restart`)
  4. Within 5–7 min, `Payment recovery scan` should pick up the stale row, look at the Transaction's on-chain status, and finalize.
  5. Verify Job ends in `COMPLETED` (if tx confirmed before crash) or `PAYMENT_FAILED` (if tx had failed or never broadcast).
- [ ] Quiet-state validation: `Payment recovery scan: nothing to do` debug log fires on every tick when no stale rows exist (no warning noise).

## Knock-on / out-of-scope

- **#75** (admin dashboard PAYMENT_PENDING/FAILED queues + reconcile UI) becomes the **exception** path now, not the daily workflow. Operators only need to manually intervene if the recovery worker itself can't make progress (e.g. price oracle outage extending past the stale threshold). Still worth shipping for the truly-stuck cases.
- This closes the loop on the four-PR Phase 1.5 sequence: #83 → #84 → #85 → #73. After this lands, **#71 itself can be closed** in favor of separate Phase 2 (revenue snapshots) and Phase 3 (PnL refactor) tickets.

## Notes

- No DB schema changes. Pure additive logic on top of existing tables.
- Env vars (all optional, with sensible defaults): `PAYMENT_RECOVERY_INTERVAL_SEC`, `PAYMENT_RECOVERY_STALE_THRESHOLD_SEC`, `PAYMENT_RECOVERY_PER_TICK_LIMIT`.
- The Vercel `agentfi-admin` preview check is the standing flake from HANDOFF §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)