### PR TITLE
feat(admin): PAYMENT_PENDING/FAILED queue + reconcile UI (#75)

### DIFF
--- a/packages/admin/src/app/api/admin/jobs/[id]/reconcile/route.ts
+++ b/packages/admin/src/app/api/admin/jobs/[id]/reconcile/route.ts
@@ -3,29 +3,38 @@ import { NextResponse } from 'next/server';
 const API_URL = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3000';
 const ADMIN_SECRET = process.env['ADMIN_SECRET'] ?? '';
 
+/**
+ * BFF proxy for POST /admin/jobs/:id/reconcile.
+ *
+ * Forwards the {action, reason} body to the backend with the operator's
+ * x-admin-secret. Mirrors the existing pattern in
+ * /api/transactions/[id]/approve so we never ship ADMIN_SECRET to the
+ * browser.
+ */
 export async function POST(
   request: Request,
   context: { params: Promise<{ id: string }> },
 ) {
   const { id } = await context.params;
   try {
-    const res = await fetch(`${API_URL}/admin/transactions/${id}/approve`, {
+    const body = await request.text();
+    const res = await fetch(`${API_URL}/admin/jobs/${id}/reconcile`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'x-admin-secret': ADMIN_SECRET,
       },
+      body,
     });
 
     const data = await res.json().catch(() => ({}));
-    
+
     if (!res.ok) {
       return NextResponse.json(data, { status: res.status });
     }
-
     return NextResponse.json(data);
   } catch (err) {
-    console.error('Approval proxy failed:', err);
+    console.error('Job reconcile proxy failed:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/packages/admin/src/app/api/agents/[id]/pause/route.test.ts
+++ b/packages/admin/src/app/api/agents/[id]/pause/route.test.ts
@@ -20,7 +20,7 @@ describe('admin agent pause route auth guard', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
     const res = await POST(new Request('http://localhost/api/agents/test/pause'), {
-      params: { id: 'test-agent' },
+      params: Promise.resolve({ id: 'test-agent' }),
     });
     const body = (await res.json()) as { error: string };
 
@@ -42,7 +42,7 @@ describe('admin agent pause route auth guard', () => {
     );
 
     const res = await POST(new Request('http://localhost/api/agents/test/pause'), {
-      params: { id: 'test-agent' },
+      params: Promise.resolve({ id: 'test-agent' }),
     });
     const body = (await res.json()) as { success: boolean };
 

--- a/packages/admin/src/app/api/agents/[id]/pause/route.ts
+++ b/packages/admin/src/app/api/agents/[id]/pause/route.ts
@@ -4,13 +4,17 @@ import { hasAdminSession } from '../../../../../lib/session';
 const BACKEND_URL = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3000';
 const ADMIN_SECRET = process.env['ADMIN_SECRET'] ?? '';
 
-export async function POST(_req: Request, { params }: { params: { id: string } }) {
+export async function POST(
+  _req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
   const authorized = await hasAdminSession();
   if (!authorized) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const res = await fetch(`${BACKEND_URL}/admin/agents/${params.id}/pause`, {
+  const res = await fetch(`${BACKEND_URL}/admin/agents/${id}/pause`, {
     method: 'POST',
     headers: { 'x-admin-secret': ADMIN_SECRET },
   });

--- a/packages/admin/src/app/api/transactions/[id]/reject/route.ts
+++ b/packages/admin/src/app/api/transactions/[id]/reject/route.ts
@@ -5,10 +5,11 @@ const ADMIN_SECRET = process.env['ADMIN_SECRET'] ?? '';
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> },
 ) {
+  const { id } = await context.params;
   try {
-    const res = await fetch(`${API_URL}/admin/transactions/${params.id}/reject`, {
+    const res = await fetch(`${API_URL}/admin/transactions/${id}/reject`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/admin/src/app/dashboard/page.tsx
+++ b/packages/admin/src/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
+import Link from 'next/link';
 import { adminFetch } from '../../lib/api';
 import { StatCard } from '../../components/StatCard';
 import { VolumeChart } from '../../components/Chart';
-import { Users, Activity, CheckCircle, AlertCircle, DollarSign, Wallet } from 'lucide-react';
+import { Users, Activity, CheckCircle, AlertCircle, DollarSign, Wallet, Clock, AlertTriangle } from 'lucide-react';
 
 interface DashboardStats {
   activeAgents: number;
@@ -10,6 +11,9 @@ interface DashboardStats {
   failedToday: number;
   volumeToday: string;
   totalFeesUsd: string;
+  paymentPending: number;
+  paymentFailed: number;
+  stalePaymentPending: number;
 }
 
 async function getStats(): Promise<DashboardStats> {
@@ -24,12 +28,16 @@ async function getStats(): Promise<DashboardStats> {
       failedToday: 0,
       volumeToday: '0',
       totalFeesUsd: '0',
+      paymentPending: 0,
+      paymentFailed: 0,
+      stalePaymentPending: 0,
     };
   }
 }
 
 export default async function DashboardPage() {
   const stats = await getStats();
+  const hasPaymentAlert = stats.stalePaymentPending > 0 || stats.paymentFailed > 0;
 
   return (
     <div className="space-y-8 animate-in fade-in duration-700">
@@ -40,6 +48,33 @@ export default async function DashboardPage() {
         </div>
       </div>
 
+      {hasPaymentAlert && (
+        <Link
+          href="/jobs?status=PAYMENT_PENDING"
+          className="block p-4 rounded-xl bg-yellow-400/5 border border-yellow-400/30 hover:bg-yellow-400/10 transition-colors"
+        >
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="size-5 text-yellow-400 shrink-0" />
+            <div className="flex-1">
+              <p className="text-yellow-400 font-medium text-sm">
+                {stats.stalePaymentPending > 0 && (
+                  <>
+                    {stats.stalePaymentPending} stale PAYMENT_PENDING job{stats.stalePaymentPending !== 1 ? 's' : ''} (&gt; 5 min)
+                  </>
+                )}
+                {stats.stalePaymentPending > 0 && stats.paymentFailed > 0 && ' · '}
+                {stats.paymentFailed > 0 && (
+                  <>
+                    {stats.paymentFailed} PAYMENT_FAILED awaiting reconcile
+                  </>
+                )}
+              </p>
+              <p className="text-yellow-400/70 text-xs mt-0.5">Click to triage on the Jobs page.</p>
+            </div>
+          </div>
+        </Link>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
         <StatCard label="Active Agents" value={stats.activeAgents.toString()} icon={<Users className="size-4" />} delay={0.1} />
         <StatCard label="Total Txs" value={stats.totalTransactions.toString()} icon={<Activity className="size-4" />} delay={0.2} />
@@ -49,10 +84,34 @@ export default async function DashboardPage() {
         <StatCard label="Protocol Fees" value={`$${parseFloat(stats.totalFeesUsd).toFixed(2)}`} icon={<Wallet className="size-4" />} delay={0.6} sub="total earned" />
       </div>
 
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <StatCard
+          label="Payment Pending"
+          value={stats.paymentPending.toString()}
+          icon={<Clock className="size-4" />}
+          delay={0.7}
+          sub={stats.stalePaymentPending > 0 ? `${stats.stalePaymentPending} stale` : 'in-flight'}
+        />
+        <StatCard
+          label="Payment Failed"
+          value={stats.paymentFailed.toString()}
+          icon={<AlertCircle className="size-4" />}
+          delay={0.8}
+          sub={stats.paymentFailed > 0 ? 'awaiting reconcile' : 'clean'}
+        />
+        <StatCard
+          label="Stale (>5 min)"
+          value={stats.stalePaymentPending.toString()}
+          icon={<AlertTriangle className="size-4" />}
+          delay={0.9}
+          sub="recovery worker target"
+        />
+      </div>
+
       <div className="w-full">
         <VolumeChart />
       </div>
-      
+
       <div className="p-6 glass rounded-2xl mt-8">
         <h3 className="text-white font-medium mb-2">Protocol Mechanics</h3>
         <p className="text-gray-400 text-sm">

--- a/packages/admin/src/app/jobs/[id]/page.tsx
+++ b/packages/admin/src/app/jobs/[id]/page.tsx
@@ -1,0 +1,240 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { adminFetch } from '../../../lib/api';
+import { JobReconcileActions } from '../../../components/JobReconcileActions';
+import {
+  ArrowLeft,
+  Briefcase,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Ban,
+  ArrowRightLeft,
+} from 'lucide-react';
+
+interface Job {
+  id: string;
+  status:
+    | 'PENDING'
+    | 'ACCEPTED'
+    | 'COMPLETED'
+    | 'FAILED'
+    | 'CANCELLED'
+    | 'PAYMENT_PENDING'
+    | 'PAYMENT_FAILED';
+  reservationStatus?: 'PENDING' | 'RELEASED' | 'CANCELLED' | null;
+  reservedAmount?: string | null;
+  reservedToken?: string | null;
+  reservedChainId?: number | null;
+  reservedAt?: string | null;
+  payload: any;
+  reward: any;
+  result?: any;
+  signature?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  requester: { id: string; name: string };
+  provider: { id: string; name: string };
+}
+
+const STATUS_CONFIG: Record<
+  Job['status'],
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  PENDING: {
+    label: 'PENDING',
+    color: 'text-brand-purple bg-brand-purple/10 ring-brand-purple/30',
+    icon: <Clock className="size-4" />,
+  },
+  ACCEPTED: {
+    label: 'ACCEPTED',
+    color: 'text-brand-accent bg-brand-accent/10 ring-brand-accent/30',
+    icon: <ArrowRightLeft className="size-4" />,
+  },
+  COMPLETED: {
+    label: 'COMPLETED',
+    color: 'text-brand-green bg-brand-green/10 ring-brand-green/30',
+    icon: <CheckCircle2 className="size-4" />,
+  },
+  FAILED: {
+    label: 'FAILED',
+    color: 'text-brand-red bg-brand-red/10 ring-brand-red/30',
+    icon: <XCircle className="size-4" />,
+  },
+  CANCELLED: {
+    label: 'CANCELLED',
+    color: 'text-gray-400 bg-gray-500/10 ring-gray-500/30',
+    icon: <Ban className="size-4" />,
+  },
+  PAYMENT_PENDING: {
+    label: 'PAYMENT_PENDING',
+    color: 'text-yellow-400 bg-yellow-400/10 ring-yellow-400/30',
+    icon: <Clock className="size-4" />,
+  },
+  PAYMENT_FAILED: {
+    label: 'PAYMENT_FAILED',
+    color: 'text-brand-red bg-brand-red/10 ring-brand-red/30',
+    icon: <AlertTriangle className="size-4" />,
+  },
+};
+
+async function getJob(id: string): Promise<Job | null> {
+  try {
+    // The backend has GET /v1/jobs/:id (auth via API key) and a list at
+    // /admin/jobs. There's no per-id admin endpoint yet, so we list with a
+    // wide window and pick. Cheap (single-row index hit) and avoids a new
+    // backend route just for the detail view.
+    const res = await adminFetch<{ jobs: Job[] }>(`/admin/jobs?limit=200`);
+    return res.jobs.find((j) => j.id === id) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const CHAIN_NAMES: Record<number, string> = {
+  1: 'Ethereum',
+  8453: 'Base',
+  42161: 'Arbitrum',
+  137: 'Polygon',
+};
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const job = await getJob(id);
+  if (!job) notFound();
+
+  const statusCfg = STATUS_CONFIG[job.status] ?? STATUS_CONFIG.PENDING;
+  const reward =
+    job.reward && typeof job.reward === 'object' ? (job.reward as any) : null;
+  const reservedChain = job.reservedChainId ? CHAIN_NAMES[job.reservedChainId] ?? job.reservedChainId : null;
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-700">
+      <Link
+        href="/jobs"
+        className="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors"
+      >
+        <ArrowLeft className="size-4" />
+        Back to jobs
+      </Link>
+
+      <div className="flex items-start justify-between gap-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-white mb-2 flex items-center gap-2">
+            <Briefcase className="text-brand-purple size-6" />
+            Job <code className="font-mono text-base text-gray-400">{job.id}</code>
+          </h1>
+          <div
+            className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium ring-1 inset-ring ${statusCfg.color}`}
+          >
+            {statusCfg.icon}
+            <span>{statusCfg.label}</span>
+          </div>
+        </div>
+      </div>
+
+      {(job.status === 'PAYMENT_PENDING' || job.status === 'PAYMENT_FAILED') && (
+        <JobReconcileActions jobId={job.id} status={job.status} />
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-xs text-gray-500 mb-1 uppercase tracking-wider">Requester</p>
+          <p className="text-white font-medium">{job.requester.name}</p>
+          <code className="text-xs text-gray-400 block mt-1 truncate">
+            {job.requester.id}
+          </code>
+        </div>
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-xs text-gray-500 mb-1 uppercase tracking-wider">Provider</p>
+          <p className="text-white font-medium">{job.provider.name}</p>
+          <code className="text-xs text-gray-400 block mt-1 truncate">
+            {job.provider.id}
+          </code>
+        </div>
+      </div>
+
+      <div className="glass rounded-xl p-5 border border-brand-border">
+        <p className="text-xs text-gray-500 mb-3 uppercase tracking-wider">Reward & Escrow</p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <p className="text-xs text-gray-500">Reward</p>
+            <p className="text-white font-medium text-sm mt-0.5">
+              {reward?.amount ? `${reward.amount} ${reward.token ?? 'ETH'}` : '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Chain</p>
+            <p className="text-white font-medium text-sm mt-0.5">
+              {reward?.chainId ? CHAIN_NAMES[reward.chainId] ?? reward.chainId : '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Reservation</p>
+            <p
+              className={`font-medium text-sm mt-0.5 ${
+                job.reservationStatus === 'PENDING'
+                  ? 'text-yellow-400'
+                  : job.reservationStatus === 'RELEASED'
+                    ? 'text-brand-green'
+                    : job.reservationStatus === 'CANCELLED'
+                      ? 'text-gray-400'
+                      : 'text-gray-600'
+              }`}
+            >
+              {job.reservationStatus ?? '—'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Reserved Amount</p>
+            <p className="text-white font-medium text-sm mt-0.5">
+              {job.reservedAmount
+                ? `${job.reservedAmount} ${job.reservedToken ?? 'ETH'}`
+                : '—'}
+            </p>
+          </div>
+        </div>
+        {reservedChain && job.reservedAt && (
+          <p className="text-[11px] text-gray-500 mt-3">
+            Reserved on {reservedChain} at {new Date(job.reservedAt).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-xs text-gray-500 mb-2 uppercase tracking-wider">Payload</p>
+          <pre className="text-xs text-gray-300 font-mono bg-black/40 p-3 rounded overflow-x-auto max-h-64">
+            {JSON.stringify(job.payload, null, 2)}
+          </pre>
+        </div>
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-xs text-gray-500 mb-2 uppercase tracking-wider">Result</p>
+          {job.result ? (
+            <pre className="text-xs text-gray-300 font-mono bg-black/40 p-3 rounded overflow-x-auto max-h-64">
+              {JSON.stringify(job.result, null, 2)}
+            </pre>
+          ) : (
+            <p className="text-sm text-gray-600 italic">No result recorded.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-gray-400">
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-gray-500 mb-1 uppercase tracking-wider">Created</p>
+          <p>{new Date(job.createdAt).toLocaleString()}</p>
+        </div>
+        <div className="glass rounded-xl p-5 border border-brand-border">
+          <p className="text-gray-500 mb-1 uppercase tracking-wider">Last updated</p>
+          <p>{new Date(job.updatedAt).toLocaleString()}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/app/jobs/page.tsx
+++ b/packages/admin/src/app/jobs/page.tsx
@@ -1,0 +1,250 @@
+import Link from 'next/link';
+import { adminFetch } from '../../lib/api';
+import {
+  Briefcase,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  ArrowRightLeft,
+  Ban,
+} from 'lucide-react';
+
+interface Job {
+  id: string;
+  status:
+    | 'PENDING'
+    | 'ACCEPTED'
+    | 'COMPLETED'
+    | 'FAILED'
+    | 'CANCELLED'
+    | 'PAYMENT_PENDING'
+    | 'PAYMENT_FAILED';
+  reservationStatus?: 'PENDING' | 'RELEASED' | 'CANCELLED' | null;
+  reservedAmount?: string | null;
+  reservedToken?: string | null;
+  reservedChainId?: number | null;
+  payload: any;
+  reward: any;
+  result?: any;
+  createdAt: string;
+  updatedAt: string;
+  requester: { id: string; name: string };
+  provider: { id: string; name: string };
+}
+
+const STATUS_CONFIG: Record<
+  Job['status'],
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  PENDING: {
+    label: 'PENDING',
+    color: 'text-brand-purple bg-brand-purple/10 ring-brand-purple/30',
+    icon: <Clock className="size-3" />,
+  },
+  ACCEPTED: {
+    label: 'ACCEPTED',
+    color: 'text-brand-accent bg-brand-accent/10 ring-brand-accent/30',
+    icon: <ArrowRightLeft className="size-3" />,
+  },
+  COMPLETED: {
+    label: 'COMPLETED',
+    color: 'text-brand-green bg-brand-green/10 ring-brand-green/30',
+    icon: <CheckCircle2 className="size-3" />,
+  },
+  FAILED: {
+    label: 'FAILED',
+    color: 'text-brand-red bg-brand-red/10 ring-brand-red/30',
+    icon: <XCircle className="size-3" />,
+  },
+  CANCELLED: {
+    label: 'CANCELLED',
+    color: 'text-gray-400 bg-gray-500/10 ring-gray-500/30',
+    icon: <Ban className="size-3" />,
+  },
+  PAYMENT_PENDING: {
+    label: 'PAYMENT_PENDING',
+    color: 'text-yellow-400 bg-yellow-400/10 ring-yellow-400/30',
+    icon: <Clock className="size-3" />,
+  },
+  PAYMENT_FAILED: {
+    label: 'PAYMENT_FAILED',
+    color: 'text-brand-red bg-brand-red/10 ring-brand-red/30',
+    icon: <AlertTriangle className="size-3" />,
+  },
+};
+
+const FILTER_CHIPS: Array<{ label: string; value: string | null }> = [
+  { label: 'All', value: null },
+  { label: 'Pending', value: 'PENDING' },
+  { label: 'Active', value: 'ACCEPTED' },
+  { label: 'Pending Payment', value: 'PAYMENT_PENDING' },
+  { label: 'Failed Payment', value: 'PAYMENT_FAILED' },
+  { label: 'Completed', value: 'COMPLETED' },
+  { label: 'Failed', value: 'FAILED' },
+  { label: 'Cancelled', value: 'CANCELLED' },
+];
+
+async function getJobs(status: string | null): Promise<Job[]> {
+  try {
+    const res = await adminFetch<{ jobs: Job[] }>(
+      `/admin/jobs?limit=100${status ? `&status=${status}` : ''}`,
+    );
+    return res.jobs;
+  } catch {
+    return [];
+  }
+}
+
+function formatRelative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  return `${d}d ago`;
+}
+
+export default async function JobsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const params = await searchParams;
+  const activeStatus = params.status ?? null;
+  const jobs = await getJobs(activeStatus);
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-700">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-white mb-1 flex items-center gap-2">
+            <Briefcase className="text-brand-purple size-8" />
+            Jobs
+          </h1>
+          <p className="text-gray-400">
+            A2A service requests across all agents. Filter by lifecycle state to triage.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {FILTER_CHIPS.map((chip) => {
+          const isActive = chip.value === activeStatus;
+          const href = chip.value ? `/jobs?status=${chip.value}` : '/jobs';
+          const isAlertChip =
+            chip.value === 'PAYMENT_PENDING' || chip.value === 'PAYMENT_FAILED';
+          return (
+            <Link
+              key={chip.label}
+              href={href}
+              className={`inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                isActive
+                  ? isAlertChip
+                    ? 'bg-yellow-400/15 border-yellow-400/40 text-yellow-300'
+                    : 'bg-brand-accent/15 border-brand-accent/40 text-white'
+                  : isAlertChip
+                    ? 'bg-yellow-400/5 border-yellow-400/20 text-yellow-400/80 hover:bg-yellow-400/10'
+                    : 'bg-white/5 border-white/10 text-gray-400 hover:bg-white/10'
+              }`}
+            >
+              {chip.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="glass rounded-xl overflow-hidden border border-brand-border">
+        <table className="w-full text-sm text-left">
+          <thead className="bg-brand-black/50 text-gray-400 text-xs uppercase tracking-wider border-b border-brand-border">
+            <tr>
+              <th className="px-6 py-4 font-semibold">Status</th>
+              <th className="px-6 py-4 font-semibold">Job</th>
+              <th className="px-6 py-4 font-semibold">Requester → Provider</th>
+              <th className="px-6 py-4 font-semibold">Reward</th>
+              <th className="px-6 py-4 font-semibold">Escrow</th>
+              <th className="px-6 py-4 font-semibold">Updated</th>
+              <th className="px-6 py-4 font-semibold text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-brand-border/50">
+            {jobs.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-6 py-12 text-center text-gray-500">
+                  <div className="flex flex-col items-center justify-center">
+                    <Briefcase className="size-12 text-gray-600 mb-3" />
+                    <p>No jobs match this filter.</p>
+                  </div>
+                </td>
+              </tr>
+            )}
+            {jobs.map((job) => {
+              const statusCfg = STATUS_CONFIG[job.status] ?? STATUS_CONFIG.PENDING;
+              const reward =
+                job.reward && typeof job.reward === 'object' ? (job.reward as any) : null;
+              const rewardLabel = reward?.amount
+                ? `${reward.amount} ${reward.token ?? 'ETH'}`
+                : '—';
+              return (
+                <tr key={job.id} className="hover:bg-white/[0.02] transition-colors group">
+                  <td className="px-6 py-4">
+                    <div
+                      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-[4px] text-xs font-medium ring-1 inset-ring ${statusCfg.color}`}
+                    >
+                      {statusCfg.icon}
+                      <span>{statusCfg.label}</span>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4">
+                    <code className="text-xs text-gray-400 bg-black/40 px-2 py-1 rounded border border-white/5">
+                      {job.id.slice(0, 10)}…
+                    </code>
+                  </td>
+                  <td className="px-6 py-4 text-gray-300">
+                    <div className="text-xs">
+                      <span className="text-gray-400">{job.requester.name}</span>
+                      <span className="text-gray-500 mx-1.5">→</span>
+                      <span>{job.provider.name}</span>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 text-gray-300 font-medium">{rewardLabel}</td>
+                  <td className="px-6 py-4">
+                    {job.reservationStatus ? (
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium ${
+                          job.reservationStatus === 'PENDING'
+                            ? 'bg-yellow-400/10 text-yellow-400'
+                            : job.reservationStatus === 'RELEASED'
+                              ? 'bg-brand-green/10 text-brand-green'
+                              : 'bg-gray-500/10 text-gray-400'
+                        }`}
+                      >
+                        {job.reservationStatus}
+                      </span>
+                    ) : (
+                      <span className="text-gray-600 text-xs">—</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 text-gray-400 text-xs" title={job.updatedAt}>
+                    {formatRelative(job.updatedAt)}
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    <Link
+                      href={`/jobs/${job.id}`}
+                      className="inline-flex items-center gap-1.5 text-xs font-bold text-gray-400 hover:text-brand-accent transition-colors bg-white/5 hover:bg-brand-accent/10 px-3 py-1.5 rounded-lg border border-white/5 hover:border-brand-accent/30"
+                    >
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/JobReconcileActions.tsx
+++ b/packages/admin/src/components/JobReconcileActions.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
+
+interface Props {
+  jobId: string;
+  status: "PAYMENT_PENDING" | "PAYMENT_FAILED";
+}
+
+export function JobReconcileActions({ jobId, status }: Props) {
+  const router = useRouter();
+  const [pendingAction, setPendingAction] = useState<
+    "force_completed" | "force_failed" | null
+  >(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    if (!pendingAction || reason.trim().length < 3) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/jobs/${jobId}/reconcile`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: pendingAction, reason: reason.trim() }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }));
+        throw new Error(body.error ?? "Reconcile failed");
+      }
+      // Success — drop the modal and refetch the page (server component
+      // re-runs to reflect the new status).
+      setPendingAction(null);
+      setReason("");
+      router.refresh();
+    } catch (err) {
+      setError((err as Error)?.message ?? "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-yellow-400/30 bg-yellow-400/5 p-6">
+      <div className="flex items-start gap-3 mb-4">
+        <AlertTriangle className="size-5 text-yellow-400 shrink-0 mt-0.5" />
+        <div>
+          <h3 className="text-yellow-300 font-semibold text-sm">
+            Manual reconcile
+          </h3>
+          <p className="text-yellow-400/70 text-xs mt-1 leading-relaxed">
+            This Job is in <code className="font-mono text-yellow-300">{status}</code>.
+            Use these actions only when you've verified the on-chain state
+            externally and the recovery worker can't resolve it automatically.
+            Both actions are <strong>logged with audit context</strong>.
+          </p>
+        </div>
+      </div>
+
+      {pendingAction === null && (
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => setPendingAction("force_completed")}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-brand-green/10 border border-brand-green/30 text-brand-green hover:bg-brand-green/20 transition-colors text-sm font-medium"
+          >
+            <CheckCircle2 className="size-4" />
+            Force COMPLETED
+          </button>
+          <button
+            type="button"
+            onClick={() => setPendingAction("force_failed")}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-brand-red/10 border border-brand-red/30 text-brand-red hover:bg-brand-red/20 transition-colors text-sm font-medium"
+          >
+            <XCircle className="size-4" />
+            Force FAILED + Refund
+          </button>
+        </div>
+      )}
+
+      {pendingAction !== null && (
+        <div className="space-y-3">
+          <div className="text-xs">
+            <span className="text-gray-400">You're about to: </span>
+            <span
+              className={
+                pendingAction === "force_completed"
+                  ? "text-brand-green font-mono font-semibold"
+                  : "text-brand-red font-mono font-semibold"
+              }
+            >
+              {pendingAction === "force_completed"
+                ? "FORCE COMPLETED — escrow marked RELEASED, reputation +1"
+                : "FORCE FAILED — escrow refunded to requester"}
+            </span>
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              Reason (required, ≥ 3 chars, lands in audit log)
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder='e.g. "Provider DM-confirmed receipt of payment off-system, tx 0x..."'
+              rows={2}
+              className="w-full bg-black/40 border border-white/10 rounded px-3 py-2 text-sm text-white placeholder:text-gray-600 focus:outline-none focus:border-brand-accent/50"
+            />
+          </div>
+
+          {error && (
+            <div className="text-xs text-brand-red bg-brand-red/10 border border-brand-red/30 rounded px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={submit}
+              disabled={submitting || reason.trim().length < 3}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/10 border border-white/20 text-white hover:bg-white/20 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Submitting…" : "Confirm"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setPendingAction(null);
+                setReason("");
+                setError(null);
+              }}
+              disabled={submitting}
+              className="inline-flex items-center px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-gray-400 hover:bg-white/10 transition-colors text-sm"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { motion } from "framer-motion";
-import { LayoutDashboard, Users, Activity, ShieldCheck, Settings } from "lucide-react";
+import { LayoutDashboard, Users, Activity, Briefcase, ShieldCheck, Settings } from "lucide-react";
 import { cn } from "../lib/utils";
 
 const navItems = [
   { name: "Overview", href: "/dashboard", icon: LayoutDashboard },
   { name: "Agents", href: "/agents", icon: Users },
   { name: "Transactions", href: "/transactions", icon: Activity },
+  { name: "Jobs", href: "/jobs", icon: Briefcase },
   { name: "Health", href: "/health", icon: ShieldCheck },
   { name: "Settings", href: "/settings", icon: Settings },
 ];

--- a/packages/backend/src/api/routes/admin.ts
+++ b/packages/backend/src/api/routes/admin.ts
@@ -144,6 +144,12 @@ export async function adminRoutes(fastify: FastifyInstance) {
     todayDate.setHours(0, 0, 0, 0);
     const todayStr = todayDate.toISOString().slice(0, 10);
 
+    // Stale PAYMENT_PENDING threshold mirrors the recovery worker's default
+    // (5 min). Anything sitting in PAYMENT_PENDING longer than that is a
+    // candidate for the recovery scan and worth surfacing on the dashboard
+    // as an at-a-glance health signal — see #73 / #75.
+    const stalePaymentPendingCutoff = new Date(Date.now() - 5 * 60 * 1000);
+
     const [
       activeAgents,
       totalTransactions,
@@ -151,6 +157,9 @@ export async function adminRoutes(fastify: FastifyInstance) {
       failedToday,
       feeEvents,
       dailyVolumes,
+      paymentPending,
+      paymentFailed,
+      stalePaymentPending,
     ] = await Promise.all([
       db.agent.count({ where: { active: true } }),
       db.transaction.count(),
@@ -167,6 +176,14 @@ export async function adminRoutes(fastify: FastifyInstance) {
       db.dailyVolume.findMany({
         where: { date: todayStr },
         select: { volumeUsd: true },
+      }),
+      db.job.count({ where: { status: 'PAYMENT_PENDING' } }),
+      db.job.count({ where: { status: 'PAYMENT_FAILED' } }),
+      db.job.count({
+        where: {
+          status: 'PAYMENT_PENDING',
+          updatedAt: { lt: stalePaymentPendingCutoff },
+        },
       }),
     ]);
 
@@ -185,6 +202,9 @@ export async function adminRoutes(fastify: FastifyInstance) {
       failedToday,
       volumeToday,
       totalFeesUsd,
+      paymentPending,
+      paymentFailed,
+      stalePaymentPending,
     };
   });
 
@@ -234,6 +254,158 @@ export async function adminRoutes(fastify: FastifyInstance) {
       });
 
       return { transactions };
+    },
+  );
+
+  /**
+   * GET /admin/jobs — global Job log with optional status filter.
+   * Issue #75: surfaces PAYMENT_PENDING / PAYMENT_FAILED queues operators
+   * previously had to query the DB directly to find.
+   */
+  fastify.get('/admin/jobs', async (request, reply) => {
+    if (!requireAdmin(request, reply)) return;
+    const query = request.query as { limit?: string; status?: string };
+    const limit = Math.min(parseInt(query.limit ?? '50'), 200);
+
+    const jobs = await db.job.findMany({
+      ...(query.status ? { where: { status: query.status as any } } : {}),
+      orderBy: { updatedAt: 'desc' },
+      take: limit,
+      include: {
+        requester: { select: { id: true, name: true } },
+        provider: { select: { id: true, name: true } },
+      },
+    });
+
+    return { jobs };
+  });
+
+  /**
+   * POST /admin/jobs/:id/reconcile — manual reconciliation for stuck/failed jobs.
+   * Issue #75: gives operators the "Force COMPLETED" / "Force FAILED + Refund"
+   * escape hatches for cases the recovery worker can't resolve automatically
+   * (operator manually verified payment off-system, etc.).
+   *
+   * Action semantics:
+   *   - force_completed: Job → COMPLETED, escrow marked RELEASED, reputation
+   *     awarded. Use when payment has been verified through other means.
+   *   - force_failed:    Job → PAYMENT_FAILED, escrow refunded to requester.
+   *     Use when a stuck PAYMENT_PENDING is confirmed never to settle.
+   *
+   * Audit trail lands in the structured logger output (operator-facing log
+   * shipping captures it). For now we don't persist a separate JobAuditLog
+   * table — the structured logs are the audit trail.
+   */
+  const reconcileSchema = z.object({
+    action: z.enum(['force_completed', 'force_failed']),
+    reason: z.string().min(3).max(500),
+  });
+
+  fastify.post<{ Params: { id: string } }>(
+    '/admin/jobs/:id/reconcile',
+    async (request, reply) => {
+      if (!requireAdmin(request, reply)) return;
+
+      const parsed = reconcileSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.code(400).send({
+          error: 'Invalid request body',
+          details: parsed.error.flatten().fieldErrors,
+        });
+      }
+      const { action, reason } = parsed.data;
+
+      const job = await db.job.findUnique({
+        where: { id: request.params.id },
+        select: {
+          id: true,
+          status: true,
+          providerId: true,
+          requesterId: true,
+          reservationStatus: true,
+          reward: true,
+        },
+      });
+      if (!job) return reply.code(404).send({ error: 'Job not found' });
+
+      // Only allow reconcile on payment-state jobs to avoid accidental
+      // overrides on healthy lifecycle states (PENDING/ACCEPTED/COMPLETED/etc).
+      if (job.status !== 'PAYMENT_PENDING' && job.status !== 'PAYMENT_FAILED') {
+        return reply.code(409).send({
+          error: `Job is in ${job.status} status; reconcile only valid for PAYMENT_PENDING / PAYMENT_FAILED.`,
+        });
+      }
+
+      // Refund-then-flip ordering, mirroring the finalizer (#85 lesson) so
+      // any concurrent observer sees a consistent state.
+      try {
+        if (action === 'force_completed') {
+          if (job.reservationStatus === 'PENDING') {
+            // Mark as RELEASED (consumed by payment), don't refund — operator
+            // claims payment happened off-system.
+            await db.job.update({
+              where: { id: job.id },
+              data: { reservationStatus: 'RELEASED' },
+            });
+          }
+          await reputationService.recordJobOutcome(job.providerId, true);
+          await db.job.update({
+            where: { id: job.id },
+            data: { status: 'COMPLETED' },
+          });
+        } else {
+          // force_failed
+          if (job.reservationStatus === 'PENDING') {
+            // Refund: same path as releaseJobEscrow used by the automated
+            // finalizer. We use the existing helper so DailyVolume is
+            // adjusted consistently.
+            const { releaseJobEscrow } = await import(
+              '../../services/policy/escrow.service.js'
+            );
+            await releaseJobEscrow(job.id);
+          }
+          await db.job.update({
+            where: { id: job.id },
+            data: { status: 'PAYMENT_FAILED' },
+          });
+        }
+      } catch (err) {
+        logger.error(
+          {
+            jobId: job.id,
+            action,
+            reason,
+            err: (err as Error)?.message ?? String(err),
+          },
+          'Admin reconcile failed mid-write — manual DB inspection required',
+        );
+        return reply.code(500).send({
+          error: 'Reconcile failed mid-write; check server logs.',
+        });
+      }
+
+      logger.warn(
+        {
+          adminAction: 'job_reconcile',
+          jobId: job.id,
+          action,
+          reason,
+          previousStatus: job.status,
+          providerId: job.providerId,
+          requesterId: job.requesterId,
+          // request.ip captures origin IP but operator identity beyond
+          // ADMIN_SECRET-holder isn't tracked yet (no per-operator auth).
+          remoteIp: request.ip,
+        },
+        'Admin manually reconciled a payment job',
+      );
+
+      return {
+        jobId: job.id,
+        previousStatus: job.status,
+        newStatus: action === 'force_completed' ? 'COMPLETED' : 'PAYMENT_FAILED',
+        reservationStatus: action === 'force_completed' ? 'RELEASED' : 'CANCELLED',
+      };
     },
   );
 


### PR DESCRIPTION
## Summary

Closes #75. Adds operator-facing surfacing and manual escape hatches for the intermediate Job lifecycle states introduced in Phase 1 of #71. Closes the visibility gap that previously forced operators to query the database directly to find stuck/failed payment jobs.

After this lands, the four-PR Phase 1.5 sequence (#83 / #84 / #85 / #86 / #75) is complete and **#71 itself can be closed** in favor of separate Phase 2 / Phase 3 tickets.

## Backend (`packages/backend/src/api/routes/admin.ts`)

| Endpoint | Purpose |
|---|---|
| `GET /admin/jobs?status=&limit=` | Global Job log with optional status filter; includes requester/provider names. Same admin auth + IP-loopback gate as the rest of `/admin/*`. |
| `POST /admin/jobs/:id/reconcile` body `{action, reason}` | Manual override for stuck payment jobs. `action` is `force_completed` (Job → COMPLETED, escrow RELEASED, reputation +1 — for off-system payment confirmation) or `force_failed` (Job → PAYMENT_FAILED, escrow refunded via the same `releaseJobEscrow` the automated finalizer uses). Both follow the refund-then-flip ordering established in #85. `reason` (≥3 chars) lands in the structured logger output as the audit trail. |
| `GET /admin/stats` *(extended)* | Three new counters: `paymentPending`, `paymentFailed`, `stalePaymentPending` (>5 min — same threshold as the recovery worker in #86). |

**Audit trail decision:** logged via `logger.warn({adminAction, jobId, action, reason, previousStatus, ...})`. No separate `JobAuditLog` table for now — production logs are persisted and queryable. Easy to upgrade to a table later if structured per-operator audit becomes a requirement.

## Admin frontend (`packages/admin`)

- **Sidebar**: new "Jobs" entry between Transactions and Health.
- **Dashboard**: alert banner when `stalePaymentPending` or `paymentFailed > 0`, linking to the filtered Jobs page. Three new `StatCard`s on a second row for the payment-state counters.
- **`/jobs` page**: list with filter chips (All / Pending / Active / Pending Payment / Failed Payment / Completed / Failed / Cancelled). The two payment-state chips get yellow alert styling to be visually distinct from healthy lifecycle states.
- **`/jobs/[id]` detail page**: full Job inspection (requester/provider, reward, escrow, payload, result, timestamps). The reconcile UI surfaces **only** when status is `PAYMENT_PENDING` or `PAYMENT_FAILED` to prevent accidental overrides on healthy lifecycle states.
- **`JobReconcileActions` client component**: two-step UX (button → reason textarea → confirm) so operators can't fat-finger a force action. Posts to a new BFF proxy at `/api/admin/jobs/[id]/reconcile` that forwards the body with the operator's `x-admin-secret` (mirroring the existing `/api/transactions/[id]/approve` pattern so `ADMIN_SECRET` never leaks to the browser).

## Drive-by fix (unblocks the standing Vercel admin preview break, HANDOFF §7)

- `/api/agents/[id]/pause`, `/api/transactions/[id]/approve` and `/api/transactions/[id]/reject` route handlers were using the Next.js 14 sync `{ params }: { params: { id: string } }` shape, which Next.js 15 rejects (`params` must be `Promise<{...}>`). Bumped all three to the v15 contract — same shape my new reconcile route uses. With these fixed, `next build` no longer errors on the route validator step.
- Note: there's a remaining pre-existing prerender error on `/login` (`useSearchParams` without Suspense) that was NOT introduced here. Out of scope for this PR — separate cleanup ticket if you want to fully unbreak Vercel.

## Test plan

- [x] `npm run typecheck --workspaces --if-present` — green across all 4 workspaces
- [x] `next build` in `packages/admin` — passes route-handler type check; only fails on the unrelated `/login` Suspense issue
- [ ] After deploy:
  - Visit `/jobs` — confirm filter chips work (each chip swaps the listing)
  - Click into a `PAYMENT_PENDING` job — confirm the reconcile UI is visible, with the two-step Force COMPLETED / Force FAILED + Refund flow
  - Trigger a force action on a test job — verify status flips, escrow updates correctly, and `Admin manually reconciled a payment job` appears in `flyctl logs`
  - Visit `/jobs?status=COMPLETED` — confirm reconcile UI is NOT shown (status guard)
  - Visit `/dashboard` — confirm the alert banner appears when there are stale or failed payment jobs

## Notes

- No DB schema changes — pure additive on existing tables.
- This closes the loop on Phase 1.5. After merge: close #71, file separate Phase 2 (revenue snapshots) and Phase 3 (PnL refactor) tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)