### PR TITLE
chore(deps): merge low-risk dependabot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4791,9 +4791,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "funding": [
         {
           "type": "opencollective",
@@ -4810,8 +4810,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -4898,9 +4898,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5017,9 +5017,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5036,11 +5036,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5200,9 +5200,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5880,9 +5880,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "license": "ISC"
     },
     "node_modules/elliptic": {
@@ -8388,9 +8388,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -11748,7 +11748,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@tanstack/react-query": "^5.28.0",
-        "autoprefixer": "^10.4.0",
+        "autoprefixer": "^10.5.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.38.0",
@@ -11856,7 +11856,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8599,9 +8599,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.15",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.15.tgz",
-      "integrity": "sha512-3TubCmbKen/cuZQzX0qDbOS5lojjdSZ90lqKxWIDWd5siuJ0IJBaTXMYs8eMPLcraqnOwGZazz3apHPGiRCkGQ==",
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
+      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
       "funding": [
         {
           "type": "github",
@@ -10915,9 +10915,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.14",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.14.tgz",
-      "integrity": "sha512-PHmJF1dfa9HEfrVshFXFkixzh/22Z3VFXN1omeFfjMoOFDGQkghsRdDW+KcE29gzM7KZ+MC04L+xpbm2G/kOkw==",
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.1.tgz",
+      "integrity": "sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==",
       "funding": [
         {
           "type": "github",
@@ -10932,7 +10932,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.15",
+        "ox": "0.14.17",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -11814,7 +11814,7 @@
         "pino": "^8.19.0",
         "pino-pretty": "^13.1.3",
         "stripe": "^15.3.0",
-        "viem": "^2.47.14",
+        "viem": "^2.48.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -11856,7 +11856,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2241,15 +2241,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -7590,9 +7581,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -11809,7 +11800,7 @@
         "fastify": "^5.8.5",
         "fastify-plugin": "^5.1.0",
         "ioredis": "^5.3.2",
-        "jose": "^5.2.4",
+        "jose": "^6.2.2",
         "nanoid": "^5.0.7",
         "pino": "^8.19.0",
         "pino-pretty": "^13.1.3",
@@ -11856,7 +11847,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "eslint": "^8.57.0",
         "openapi-typescript": "^7.4.0",
-        "prettier": "^3.8.2",
+        "prettier": "^3.8.3",
         "tsx": "^4.7.0",
         "typescript": "^5.4.0"
       },
@@ -9211,9 +9211,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -11856,7 +11856,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3887,9 +3887,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.95.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
-      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3897,12 +3897,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.95.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
-      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.95.2"
+        "@tanstack/query-core": "5.99.2"
       },
       "funding": {
         "type": "github",
@@ -11747,7 +11747,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
-        "@tanstack/react-query": "^5.28.0",
+        "@tanstack/react-query": "^5.99.2",
         "autoprefixer": "^10.4.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -11856,7 +11856,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5100,9 +5100,9 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.73.5",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.73.5.tgz",
-      "integrity": "sha512-bZu3t1c/1smbA8Jk46OrLA4JRHPTv4uLbqUP0uaviV7S4c/rSl/qKmg3twgKKz+3aB4E0NL0jcjQW5eHwGyQOw==",
+      "version": "5.74.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.74.1.tgz",
+      "integrity": "sha512-GfJEos2zoOGM9xqkB7VZouwwFuejKFqm667cBcmbBekJXKqqXWk4QYP3Uy2pzgUwCbg1cR7GgGmGczM7fnhWSA==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
@@ -11803,7 +11803,7 @@
         "@prisma/client": "^5.11.0",
         "@safe-global/protocol-kit": "^4.0.0",
         "@turnkey/sdk-server": "^1.3.0",
-        "bullmq": "^5.73.5",
+        "bullmq": "^5.74.1",
         "dotenv": "^17.4.2",
         "ethers": "^5.7.2",
         "fastify": "^5.8.5",
@@ -11856,7 +11856,7 @@
     },
     "packages/mcp-server": {
       "name": "@agent_fi/mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "typescript": "^5.4.0",
     "tsx": "^4.7.0",
-    "prettier": "^3.8.2",
+    "prettier": "^3.8.3",
     "eslint": "^8.57.0",
     "openapi-typescript": "^7.4.0"
   },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
-    "@tanstack/react-query": "^5.28.0",
+    "@tanstack/react-query": "^5.99.2",
     "autoprefixer": "^10.4.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -16,7 +16,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-query": "^5.28.0",
-    "autoprefixer": "^10.4.0",
+    "autoprefixer": "^10.5.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.38.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,7 +37,7 @@
     "@prisma/client": "^5.11.0",
     "@safe-global/protocol-kit": "^4.0.0",
     "@turnkey/sdk-server": "^1.3.0",
-    "bullmq": "^5.73.5",
+    "bullmq": "^5.74.1",
     "dotenv": "^17.4.2",
     "ethers": "^5.7.2",
     "fastify": "^5.8.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "pino": "^8.19.0",
     "pino-pretty": "^13.1.3",
     "stripe": "^15.3.0",
-    "viem": "^2.47.14",
+    "viem": "^2.48.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "ioredis": "^5.3.2",
-    "jose": "^5.2.4",
+    "jose": "^6.2.2",
     "nanoid": "^5.0.7",
     "pino": "^8.19.0",
     "pino-pretty": "^13.1.3",


### PR DESCRIPTION
## Summary

Batches the low-risk Dependabot updates that passed local verification:

- prettier 3.8.3
- bullmq 5.74.1
- autoprefixer 10.5.0
- @tanstack/react-query 5.99.2
- viem 2.48.1
- jose 6.2.2

Kept higher-risk/conflicted updates out of this batch: TypeScript, Tailwind, @safe-global/protocol-kit, and the production dependency group.

## Verification

- npm run typecheck --workspaces --if-present
- npm run lint --workspaces --if-present
- npm run test -w packages/admin
- npm run test -w packages/backend -- src/__tests__/payment-finalizer.snapshot.test.ts src/__tests__/pnl.service.test.ts
- npm run build -w packages/admin