### PR TITLE
docs: add dev smoke handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed (breaking — mcp-server 0.2.0 → 0.3.0)
-- **MCP tool rename: `request_policy_update` → `update_policy`.** Closes step 6 of [#49](https://github.com/felippeyann/agentfi/issues/49). The old name + description implied an operator-approval workflow; the tool actually wrote the policy immediately. Renamed honestly and rewrote the description: *"applies IMMEDIATELY — there is no operator approval step. The operator can audit and revert via the admin panel."* `reason` field is still required and logged for audit but does not gate the write. `@agent_fi/mcp-server` bumped to **0.3.0** (SemVer breaking); no deprecated alias — pre-1.0 project, clean rename.
+
+- **MCP tool rename: `request_policy_update` → `update_policy`.** Closes step 6 of [#49](https://github.com/felippeyann/agentfi/issues/49). The old name + description implied an operator-approval workflow; the tool actually wrote the policy immediately. Renamed honestly and rewrote the description: _"applies IMMEDIATELY — there is no operator approval step. The operator can audit and revert via the admin panel."_ `reason` field is still required and logged for audit but does not gate the write. `@agent_fi/mcp-server` bumped to **0.3.0** (SemVer breaking); no deprecated alias — pre-1.0 project, clean rename.
 
 ### Added
+
+- **Dev smoke test** — `npm run smoke:dev` runs a zero-dependency first-run validation against the local dev stack: health, agent registration, manifest publish, agent search, no-reward A2A job completion, trust report, and P&L response shape.
 - **A2A handshake — `sign_handshake` / `verify_handshake` implemented.** Closes steps 3–5 of [#49](https://github.com/felippeyann/agentfi/issues/49); previously both returned 501.
   - `POST /v1/agents/me/sign-handshake` now signs an arbitrary message with the agent's wallet via EIP-191 `personal_sign`. `LocalWalletService` uses viem's `signMessage`; `TurnkeyService` uses `signRawPayload` with `HASH_FUNCTION_NO_OP` after pre-hashing with viem's `hashMessage`, then assembles a standard 65-byte r‖s‖v signature.
   - `POST /v1/agents/verify-handshake` (public) accepts `{ message, signature, address }` or `{ message, signature, agentId }`. Tries ECDSA recovery first (works for EOA); falls back to EIP-1271 via the chain's public client for contract wallets (Safe). Returns `{ valid, address, verifiedVia: 'ecdsa' | 'eip1271' }`.
@@ -23,20 +26,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`WalletService` factory** at `packages/backend/src/services/wallet/index.ts` selects Turnkey or Local based on `WALLET_PROVIDER`; all three call sites (agent registration, health check, tx submitter) now go through the factory.
 - **9 unit tests** for `LocalWalletService` — wallet creation, distinct addresses, signing with signature recovery, lookup errors, list, health.
 - **README badges** — npm version, npm monthly downloads.
-- **`STATE.md`** at the repo root — comprehensive, point-in-time project state (purpose, stack, capabilities, phase progress). Sits between VISION.md (the *why*) and HANDOFF.md (live tasks) as required reading.
+- **`STATE.md`** at the repo root — comprehensive, point-in-time project state (purpose, stack, capabilities, phase progress). Sits between VISION.md (the _why_) and HANDOFF.md (live tasks) as required reading.
 - **README.md** refreshed to reflect shipped work: ENS identity, OpenAPI spec, mcp-server v0.2.0 on npm, P&L v2 with gas costs. Getting-Started-for-Operators section now points at the provider-agnostic deployment guide.
 - **HANDOFF.md** "Files to Read First" ordering updated to include STATE.md.
 
 ### Changed
+
 - **Self-hosted deployment posture**: AgentFi has no canonical hosted production instance — every operator runs their own. Docs rewritten to reflect this: `docs/operations/production-deploy.md` is now provider-agnostic (Railway as reference example, Fly.io/Render/Docker documented as alternatives); `release-runbook.md` updated accordingly.
 
 ### Removed
+
 - `.github/workflows/deploy-production.yml` — custom Railway-CLI deploy workflow. Provider-native GitHub integrations (Railway/Fly/Render) auto-deploy on merge to `main` or on tag; the custom workflow added coupling without value.
 - `scripts/check-production-deploy-env.mjs` and `scripts/run-deploy-preflight-scenarios.mjs` — preflight tied to the deleted workflow.
 - `Deploy Preflight Check` CI job (ci.yml) — validated the removed preflight script; not a required status check.
 - Preflight invocation in `scripts/release-v1.mjs`.
 
 ### Added
+
 - **OpenAPI 3.0.3 spec** at [`docs/api/openapi.yaml`](docs/api/openapi.yaml) — machine-readable description of all 47 endpoints, with auth schemes, request/response schemas, and reusable error responses. Enables SDK generation, Postman/Insomnia import, and `openapi-typescript` type generation. Validates clean under `@redocly/cli lint`.
 - **Generated TypeScript types** at `packages/mcp-server/src/api.generated.ts`, produced from the OpenAPI spec by `openapi-typescript`. MCP tools (and any future SDK) can now import `components['schemas']['PnLBreakdown']`, `['Agent']`, etc. instead of re-declaring them.
 - **New npm scripts at repo root**: `spec:lint` (Redocly lint), `spec:types` (regenerate types), `spec:check` (CI drift check — fails if the generated file is stale relative to the spec).
@@ -112,13 +118,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - npm scope changed from `@agentfi` to `@agent_fi`
 
 ### Changed
-- A2A handshake endpoints now return 501 until proper Turnkey/EIP-1271 integration
+
 - Branch consolidation: all development unified on `main` (default), `master` deleted
 - CI workflow triggers updated from `master` to `main`
 - Next.js upgraded from v14 to v16 (admin dashboard)
 - Dockerfiles now run as non-root user (`appuser:1001`)
 
 ### Fixed
+
 - FK constraint violation in test cleanup (Job records blocking Agent deletion)
 - Test cleanup order in agent.search.test.ts and transaction.e2e.ts
 - NODE_ENV validation: added 'test' to accepted enum values
@@ -128,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - npm dependency vulnerabilities (path-to-regexp, picomatch, Next.js HIGH severity)
 
 ### Security
+
 - Admin secret comparison now uses `timingSafeEqual` (prevents timing attacks)
 - Daily volume limit check is now atomic (prevents TOCTOU race condition)
 - Agent search endpoint no longer exposes `safeAddress` in public responses
@@ -135,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auth middleware: early return on failed operator secret prevents fall-through
 
 ### Removed
+
 - `desktop.ini` from repository (added to .gitignore)
 - Placeholder A2A signature generation (security risk)
 - Placeholder A2A verification returning `valid: true` unconditionally
@@ -142,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-03-25
 
 ### Added
+
 - Initial release
 - Agent registration with Turnkey MPC wallets
 - Safe smart wallet deployment per agent

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
 # HANDOFF — AgentFi
 
-> Live pending tasks, credentials inventory, and working conventions. For *what the project is*, read [STATE.md](STATE.md). For *why*, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
+> Live pending tasks, credentials inventory, and working conventions. For _what the project is_, read [STATE.md](STATE.md). For _why_, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: April 2026 · **main SHA** `084a086` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
+**Last updated**: May 2026 · **main SHA** `81c778c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
 
 ---
 
@@ -20,20 +20,20 @@
 
 ## 1. Snapshot
 
-| Item | Value |
-|---|---|
-| Default branch | `main` (protected; required checks: Lint, Admin, Backend, Foundry) |
-| Active branches | `main`, `develop` (mirrors main post-merge) |
-| Open PRs | 0 |
-| Open issues | 0 |
-| CI | 6/6 green (5 required + OpenAPI Spec) |
-| npm vulnerabilities | 0 critical, 0 high |
-| Secrets in git history | None |
+| Item                   | Value                                                              |
+| ---------------------- | ------------------------------------------------------------------ |
+| Default branch         | `main` (protected; required checks: Lint, Admin, Backend, Foundry) |
+| Active branches        | `main`, `develop` (mirrors main post-merge)                        |
+| Open PRs               | 0                                                                  |
+| Open issues            | 0                                                                  |
+| CI                     | 6/6 green (5 required + OpenAPI Spec)                              |
+| npm vulnerabilities    | 0 critical, 0 high                                                 |
+| Secrets in git history | None                                                               |
 
 **Phase progress** (see [STATE.md §6](STATE.md#6-phase-progress) for detail):
 
 - Phase 1–2.5: complete.
-- Phase 3 — A2A economy + DeFi expansion: ~85%. Remaining: GMX adapter, escrow v3 (on-chain), sign/verify-handshake (blocked on Turnkey).
+- Phase 3 — A2A economy + DeFi expansion: ~90%. Remaining: GMX adapter, escrow v3 (on-chain).
 - Phase 4 — Self-sustaining agents: ~40%. Shipped: P&L v1+v2 (with gas), ENS identity. Remaining: self-funding (legal decision), revenue sharing.
 - Phase 5–6: not started.
 
@@ -41,13 +41,14 @@
 
 ## 2. Required reading order
 
-1. [VISION.md](VISION.md) — the *why*. Required.
-2. [STATE.md](STATE.md) — the *what* today.
+1. [VISION.md](VISION.md) — the _why_. Required.
+2. [STATE.md](STATE.md) — the _what_ today.
 3. This file (HANDOFF.md) — live work + working conventions.
 4. [docs/dev-quickstart.md](docs/dev-quickstart.md) — 3-min path from clone to running stack.
 5. [docs/architecture/overview.md](docs/architecture/overview.md) — 4-layer stack.
 
 **If you're coming in to ship code**, also read:
+
 - Relevant example under [`examples/`](examples/) for the surface you're touching.
 - [docs/api-reference.md](docs/api-reference.md) or [docs/api/openapi.yaml](docs/api/openapi.yaml) for the API shape.
 - [CONTRIBUTING.md](CONTRIBUTING.md) for PR conventions.
@@ -60,30 +61,29 @@ Pending work is split into four buckets. Nothing in `Done` is listed here — th
 
 ### 3.1 Manual tasks (user-only)
 
-| Task | Blocker | Notes |
-|---|---|---|
-| Awaiting mcp.so review | External | [Listing](https://mcp.so/server/agentfi-mcp-server/felippeyann) submitted; status `created`. |
-| Awaiting awesome-mcp-servers merge | External | [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091) open. Typical turnaround 1–7 days. |
-| Demo screencast | — | 2-minute Claude Desktop doing a real swap via MCP. Highest remaining non-code leverage. |
-| Setup-checklist review | — | `docs/operations/setup-checklist.md` predates `WALLET_PROVIDER=local` — some steps are now optional for dev. |
-| Branch pruning | — | ~12 merged branches on origin waiting deletion. Cosmetic. |
+| Task                               | Blocker  | Notes                                                                                                                                        |
+| ---------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Awaiting mcp.so review             | External | [Listing](https://mcp.so/server/agentfi-mcp-server/felippeyann) submitted; status `created`.                                                 |
+| Awaiting awesome-mcp-servers merge | External | [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091) was open in the last manual check; verify current state before acting. |
+| Demo screencast                    | —        | 2-minute Claude Desktop doing a real swap via MCP. Highest remaining non-code leverage.                                                      |
+| Setup-checklist review             | —        | `docs/operations/setup-checklist.md` predates `WALLET_PROVIDER=local` — some steps are now optional for dev.                                 |
 
 ### 3.2 Technical — unblocked
 
 Ranked by closure value, not effort.
 
-| Task | Phase | Effort | Value |
-|---|---|---|---|
-| Verify dev stack + 3 examples run end-to-end | — | ~15 min | **High** — CI-green ≠ functionally validated. See §6 for context. |
-| GMX / Perp adapter | 3 | 10–20 h | Closes Phase 3 DeFi surface. |
-| Escrow v3 on-chain (`EscrowModule.sol` + integration) | 3 | 30–40 h (incl. audit prep) | Closes Phase 3; funds un-spendable until terminal state. |
-| Revenue sharing (protocol ↔ self-hosted) | 4 | Design + impl | Aligns incentives per VISION.md. |
-| Contract deployment runbook | Polish | Low | `docs/operations/contract-deployment.md` only lists Base addresses. |
+| Task                                                  | Phase  | Effort                     | Value                                                                                                                                                                                                                                     |
+| ----------------------------------------------------- | ------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Verify dev stack + smoke + 3 examples run end-to-end  | —      | ~20 min                    | **High** — CI-green ≠ functionally validated. Run `docker compose -f docker-compose.dev.yml up --build`, `npm run smoke:dev`, then the 3 `examples/*` scripts. Local Docker was unavailable in the latest session, so this is still owed. |
+| GMX / Perp adapter                                    | 3      | 10–20 h                    | Closes Phase 3 DeFi surface.                                                                                                                                                                                                              |
+| Escrow v3 on-chain (`EscrowModule.sol` + integration) | 3      | 30–40 h (incl. audit prep) | Closes Phase 3; funds un-spendable until terminal state.                                                                                                                                                                                  |
+| Revenue sharing (protocol ↔ self-hosted)              | 4      | Design + impl              | Aligns incentives per VISION.md.                                                                                                                                                                                                          |
+| Contract deployment runbook                           | Polish | Low                        | `docs/operations/contract-deployment.md` only lists Base addresses.                                                                                                                                                                       |
 
 ### 3.3 Technical — blocked externally
 
-| Task | Blocked by |
-|---|---|
+| Task                     | Blocked by                                                           |
+| ------------------------ | -------------------------------------------------------------------- |
 | Self-funding sub-wallets | Legal decision (who owns the sub-wallet when an agent provisions it) |
 
 ### 3.4 The meta-guidance
@@ -94,17 +94,17 @@ The live project state has **completed plumbing but zero users**. Adding more co
 
 ## 4. Credentials inventory
 
-| Credential | When needed | Where to get |
-|---|---|---|
-| Alchemy API Key | Any real-chain interaction | https://dashboard.alchemy.com |
-| Turnkey keys (public + private + org ID) | Production wallets | https://app.turnkey.com |
-| Tenderly access key | Pre-broadcast tx simulation (optional; graceful fallback) | https://dashboard.tenderly.co |
-| Postgres URL | Always | Local Docker, Neon, Supabase, Railway PG |
-| Redis URL | Always | Local Docker, Upstash, Railway Redis |
-| npm publish access to `@agent_fi` | Publishing mcp-server | https://www.npmjs.com (invite-only org) |
-| `gh auth login` | PR + release ops | GitHub CLI |
-| Etherscan-family API keys | Contract verification | Per-chain block explorer |
-| Funded deployer EOA | Contract deployment | Hot wallet with gas |
+| Credential                               | When needed                                               | Where to get                             |
+| ---------------------------------------- | --------------------------------------------------------- | ---------------------------------------- |
+| Alchemy API Key                          | Any real-chain interaction                                | https://dashboard.alchemy.com            |
+| Turnkey keys (public + private + org ID) | Production wallets                                        | https://app.turnkey.com                  |
+| Tenderly access key                      | Pre-broadcast tx simulation (optional; graceful fallback) | https://dashboard.tenderly.co            |
+| Postgres URL                             | Always                                                    | Local Docker, Neon, Supabase, Railway PG |
+| Redis URL                                | Always                                                    | Local Docker, Upstash, Railway Redis     |
+| npm publish access to `@agent_fi`        | Publishing mcp-server                                     | https://www.npmjs.com (invite-only org)  |
+| `gh auth login`                          | PR + release ops                                          | GitHub CLI                               |
+| Etherscan-family API keys                | Contract verification                                     | Per-chain block explorer                 |
+| Funded deployer EOA                      | Contract deployment                                       | Hot wallet with gas                      |
 
 **Dev quickstart path** (for evaluation, no real credentials): `WALLET_PROVIDER=local` + stub Alchemy + docker-compose.dev.yml. See [docs/dev-quickstart.md](docs/dev-quickstart.md).
 
@@ -164,13 +164,14 @@ These are session-level lessons captured so future agents don't repeat the same 
 
 ### 6.1 Adoption signal gates code
 
-**The rule:** new features need a specific external trigger — an issue, a user ask, a concrete integration dependency. *"The roadmap says this is next"* is not a trigger; it's drift in disguise.
+**The rule:** new features need a specific external trigger — an issue, a user ask, a concrete integration dependency. _"The roadmap says this is next"_ is not a trigger; it's drift in disguise.
 
 **The evidence:** the productive work in recent sessions came from exactly two sources:
+
 1. Responding to issue #49 (three PRs #50/#51/#52, clean delivery, issue closed)
 2. Reducing adoption wall after explicit agreement that distribution was the bottleneck (dev-quickstart, 3 examples)
 
-Large features that were in the roadmap but had no external demand (GMX adapter, escrow v3) were deferred *by design*. Shipping them would have consumed context budget without validating any hypothesis.
+Large features that were in the roadmap but had no external demand (GMX adapter, escrow v3) were deferred _by design_. Shipping them would have consumed context budget without validating any hypothesis.
 
 **How to apply:** before starting anything in §3.2, ask "what happens if I don't build this?" If the answer is "nothing specific breaks and no one is waiting," stop. Work on §3.1 (distribution / manual tasks) or pause.
 
@@ -211,25 +212,30 @@ Large features that were in the roadmap but had no external demand (GMX adapter,
 ## 7. Known quirks and non-issues
 
 ### Prisma schema and migrations
+
 - Migrations are **never auto-generated** — write them manually in `packages/backend/src/db/migrations/NNNN_name/migration.sql`.
 - After editing `schema.prisma`, run `npx prisma generate --schema=packages/backend/src/db/schema.prisma`.
-- Latest migration: `0007_agent_ens` (adds `ensName` to Agent).
+- Latest migration: `0010_job_revenue_snapshot` (adds `rewardUsd` and `rewardPriceUsd` to Job).
 
 ### Dependency quirks
+
 - **Zod 3** pinned (Zod 4 requires MCP server refactor).
-- **ethers v5** still present alongside **viem v2** (legacy for @safe-global/protocol-kit compat — don't touch unless doing a full migration).
+- **ethers v5** still present alongside **viem v2** for Aave helper integration — don't remove it just because Safe protocol-kit v7 no longer uses `SafeFactory`.
 - Fastify v5 plugins: `@fastify/cors ^11`, `@fastify/helmet ^13`, `@fastify/rate-limit ^10`, `fastify-plugin ^5`.
 
 ### Windows development
+
 - Git on Windows auto-converts LF → CRLF (harmless for text, watch for file-content hash tests).
 - Cold `npm install` on NTFS: ~60–90 seconds.
 
 ### Known non-issues (don't "fix" these)
+
 - `e2e-testnet-smoke.yml` fails daily when testnet secrets are unset — intentional gate (`if: secrets.E2E_TESTNET_RPC_URL != ''`).
-- `ethers v5` low-severity vulns in `npm audit` — transitive via `@safe-global/protocol-kit`.
+- `ethers v5` remains in use for Aave helper integration; do not remove it just because Safe protocol-kit v7 migrated away from `SafeFactory`.
 - Vercel preview deploy failures on PRs — separate pipeline for admin dashboard, not a required check.
 
 ### Repo layout — landing site lives outside this monorepo
+
 The `agentfi.cc` landing site is a **separate repository**, not a workspace
 in this monorepo. The Vercel project `agentfi-landing` deploys from
 `felippeyann/agentfi-landing` (or the standalone repo connected at the
@@ -248,8 +254,15 @@ embeds a versioned API URL), open one PR per repo and merge them in
 order. Don't re-attempt monorepo consolidation without explicit user
 agreement.
 
-### Validation debt from the last session
-The three `examples/*` scripts and `docker-compose.dev.yml` passed typecheck/syntax/CI but were **not run end-to-end** by the agent that shipped them. Before shipping new examples or touching the dev stack, run through the quickstart + all three examples manually. If something breaks, fixing that comes first.
+### Validation debt from recent sessions
+
+The three `examples/*` scripts and `docker-compose.dev.yml` passed typecheck/syntax/CI but still need a local first-run validation. A smoke helper now exists:
+
+```bash
+npm run smoke:dev
+```
+
+Before shipping new examples or touching the dev stack, run through the quickstart, `npm run smoke:dev`, and all three examples manually. If something breaks, fixing that comes first.
 
 ---
 
@@ -267,6 +280,7 @@ npm test --workspace=packages/backend
 
 # Dev stack
 docker compose -f docker-compose.dev.yml up --build
+npm run smoke:dev
 node examples/a2a-collab/index.mjs
 
 # Release helpers
@@ -280,4 +294,4 @@ npm view @agent_fi/mcp-server version
 
 ---
 
-*Update this file whenever you finish a pending task or discover a new quirk. Keep it short — the goal is fastest possible onboarding, not exhaustive detail.*
+_Update this file whenever you finish a pending task or discover a new quirk. Keep it short — the goal is fastest possible onboarding, not exhaustive detail._

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -1,4 +1,4 @@
-# Session Notes — 2026-05-07
+# Session Notes — 2026-05-08
 
 > Single-point handoff doc. Update on every substantive session, prune stale
 > sections aggressively. If this file is older than a few days when you read
@@ -9,172 +9,140 @@
 
 ## Where we are right now
 
-**#71 is now fully closed end-to-end.** Phase 1.5 landed in
-#83/#84/#85/#86/#87/#88/#89. Phase 2 (revenue snapshots) and Phase 3
-(PnLService refactor) shipped together in PR **#90**, then were merged
-to `main` and mirrored to `develop`.
+`main` and `develop` are aligned at `81c778c`.
 
-The historical-integrity gap that motivated the original #71
-investigation is closed: completed jobs no longer re-price against live
-market data on every PnL load, and oracle outages can't silently zero
-out historical revenue.
+Open GitHub state after the dependency cleanup:
 
-The local/default branch state after the follow-up dependency work is:
-`main` = `develop` = `5c17e2d`.
+| Surface                       | Status                                |
+| ----------------------------- | ------------------------------------- |
+| Open PRs                      | 0                                     |
+| Open issues                   | 0                                     |
+| Required CI                   | Green on latest merged dependency PRs |
+| Remaining Dependabot blockers | None                                  |
 
-Open PRs now:
+The two previously blocked dependency PRs are closed:
 
-| PR | Status | Why |
-|----|--------|-----|
-| [#58](https://github.com/felippeyann/agentfi/pull/58) | Blocked | `@safe-global/protocol-kit` v7 removes the named `SafeFactory` export; `safe.service.ts` needs an SDK API migration, not just a package bump. |
-| [#64](https://github.com/felippeyann/agentfi/pull/64) | Blocked | TypeScript 6 conflicts with `openapi-typescript@7.x`, which declares a `typescript ^5.x` peer. |
+- [#58](https://github.com/felippeyann/agentfi/pull/58) — `@safe-global/protocol-kit` 4.1.7 -> 7.1.0 was merged after migrating `safe.service.ts` away from the removed `SafeFactory` named export.
+- [#64](https://github.com/felippeyann/agentfi/pull/64) — TypeScript 5.9.3 -> 6.0.3 was merged after isolating OpenAPI codegen to `openapi-typescript@7.13.0` + `typescript@5.9.3` through `npx`, avoiding `--legacy-peer-deps`.
 
 ---
 
-## What changed this session (2026-05-07)
+## What changed this session
 
-### Post-#90 integration follow-up
+### Safe protocol-kit v7
 
-- PR #90 was merged.
-- The admin `/login` Vercel blocker was fixed by wrapping the
-  `useSearchParams()` consumer in `Suspense` and aligning the admin
-  React / React DOM / React types versions.
-- Dependabot low-risk batch shipped through #91: Prettier, BullMQ,
-  Autoprefixer, React Query, Viem, and Jose.
-- Tailwind update shipped through #60.
-- Production dependency group shipped through #92.
-- Merged feature branches and stale remote branches were pruned.
+`packages/backend/src/services/wallet/safe.service.ts` now uses the v7 flow:
 
-### Phase 2 — Revenue snapshots (DB + finalizer)
+- `Safe.init({ predictedSafe })`
+- `createSafeDeploymentTransaction()`
+- broadcast through `viem` wallet client
+- reload the deployed Safe with `Safe.init({ safeAddress })`
+- enable `AgentPolicyModule` post-deployment
 
-Migration `0010_job_revenue_snapshot` adds two nullable columns to
-`Job`:
+CI for #58 passed: lint/typecheck, backend tests, admin tests, foundry, E2E, OpenAPI, and Vercel.
 
-- `rewardUsd` — total USD value of the reward at the moment of payment
-  confirmation.
-- `rewardPriceUsd` — price-per-token-unit at the same moment (e.g.
-  ETH/USD = `2000.000000`). Kept alongside `rewardUsd` for audit /
-  reconstruction.
+### TypeScript 6
 
-Both NULL on non-COMPLETED rows is the normal case. **NULL on a
-COMPLETED row carries semantic weight**: it means the price oracle was
-unresolved at finalization time, NOT "free job". This distinction is
-exactly what the original #71 investigation called out as the silent-
-zero bug — persisting `'0'` on oracle failure indistinguishably from a
-real zero is what causes historical revenue to "vanish". We deliberately
-write NULL instead so PnLService can fall back to live pricing AND
-surface a warning.
+The root and workspace TypeScript versions are now on `^6.0.3`.
 
-The capture happens in `payment-finalizer.service.ts` CONFIRMED branch,
-in the **same `db.job.update(...)` that flips status to COMPLETED**.
-No second round-trip, no observable intermediate state where status is
-COMPLETED but the snapshot hasn't landed yet. Refund-then-flip ordering
-established in #85 is preserved.
+The `openapi-typescript` peer blocker remains real upstream (`typescript: ^5.x`), so it was removed from root `devDependencies`. The codegen scripts now invoke a pinned toolchain only where needed:
 
-### Phase 3 — PnLService refactor
+```bash
+npx --yes --package openapi-typescript@7.13.0 --package typescript@5.9.3 openapi-typescript ...
+```
 
-Both reward loops (earnings as provider, costs as requester) now read
-`rewardUsd` first, falling back to live pricing only when NULL.
-Snapshot/live-fallback/unresolved counts are tracked separately for
-each side and surfaced in the `notes` field:
+Additional TS 6 compatibility fixes:
 
-> "N earning job(s) priced live (no stored snapshot) (M unresolved —
-> counted as $0; figure may understate true revenue)."
+- root `tsconfig.base.json` includes `DOM` lib and Node types for `fetch`, `RequestInit`, and `process` in Node 22 workspaces.
+- admin `tsconfig.json` no longer uses deprecated `baseUrl`.
+- `scripts/check-spec-drift.mjs` shells through `npx` only for the codegen call.
 
-Same response shape (`PnLBreakdown` interface unchanged) — admin
-dashboard reads notes as free-form strings, no frontend change needed.
+CI for #64 passed: lint/typecheck, backend tests, admin tests, foundry, E2E, OpenAPI, and Vercel.
 
-### Shared `resolveRewardUsd` helper
+### P0 diagnostic follow-up
 
-New `services/billing/reward-pricing.ts` returning
-`{ usd, priceUsd, resolved }`. Used by both the finalizer (snapshot
-capture) and PnLService (live fallback). Replaces the in-line
-`rewardToUsd` helper in `pnl.service.ts` that returned the ambiguous
-`'0'` sentinel — the boolean `resolved` field is the whole point.
+After reading `VISION.md`, the active P0s were defined as:
 
-### Tests
+1. Prove the first-run dev experience works.
+2. Keep handoff docs truthful so future agents do not chase stale blockers.
+3. Automate the first-run validation path enough that it can be repeated.
 
-- `pnl.service.test.ts` (+4 cases): snapshot priority overrides live
-  oracle; live-fallback adds a note; oracle-zero produces a visible
-  "unresolved" warning instead of silently zeroing; mixed
-  snapshot+live-fallback in one call aggregates correctly.
-- `payment-finalizer.snapshot.test.ts` (new, 4 cases): snapshot fields
-  land on the same write as `status: 'COMPLETED'`; unresolved oracle
-  ⇒ NULL columns (not `'0'`); FAILED outcome doesn't write snapshot
-  fields; the existing idempotency guard still short-circuits when the
-  Job is already terminal.
-- Both files now include a `vi.hoisted` env stub (mirroring the pattern
-  from `ens.service.test.ts`) so the suite runs locally outside CI.
+Implemented:
 
-All 16 affected tests pass. Backend `tsc --noEmit` clean.
+- `npm run smoke:dev`
+- `scripts/smoke-dev.mjs`
+- `docs/dev-quickstart.md` updated to reference the smoke test.
+- `STATE.md` and `HANDOFF.md` updated for the post-#58/#64 world.
 
-### #71 fully closed
+The smoke test checks:
 
-For the record, sub-issues all closed last session via merged PRs:
-- #73 → #86 (recovery worker)
-- #74 → #84 (idempotency via intentId)
-- #75 → #88 (admin PAYMENT_PENDING/FAILED UI)
-- #81 → #83 (lifecycle driven by on-chain outcome)
-
-#71 itself was closed in 2026-05-05 11:15Z.
+- API health
+- two local agent registrations
+- authenticated `/v1/agents/me`
+- manifest publish
+- agent search
+- no-reward A2A job create/accept/complete
+- trust report and P&L response shapes
 
 ---
 
-## Manual tasks pending on the user
+## Validation
 
-1. **`prisma migrate deploy`** in staging/prod if it has not already
-   run after #90, so the new
-   columns appear. Verify with a fresh A2A job that `Job.rewardUsd` is
-   non-null on the resulting row.
-2. **Smoke check the PnL endpoint** for an agent with mixed pre/post-
-   migration completed jobs — expect a "priced live (no stored
-   snapshot)" note naming the pre-migration row count.
-3. **(Optional)** Force a brief CoinGecko outage (network blackhole on
-   the recovery worker container) and confirm new completions land with
-   NULL snapshot + warn log, and that PnL surfaces the "unresolved"
-   note instead of silently zeroing.
+Completed locally:
 
----
+- `npm ci` passed after #64.
+- `npm run typecheck --workspaces --if-present` passed.
+- `npm run spec:check` passed.
+- `npm run spec:lint` passed.
+- `npm test -w packages/admin` passed.
+- Backend local test run reached 86/90; the remaining 4 need Postgres at `localhost:5432`.
 
-## Open follow-ups (no ticket yet — file when prioritized)
+Not completed locally:
 
-- **Backfill script for pre-migration COMPLETED rows.** Reconstruct
-  `rewardUsd` from a historical price-history feed (CoinGecko has a
-  paid endpoint; otherwise the on-chain timestamp + a daily-close feed
-  is enough for revenue accounting). Out of scope for #90.
-- **Token-registry lookup** to drop the "assume 6 decimals" MVP
-  fallback in non-ETH reward pricing. Same caveat as before #90 — it
-  didn't get worse, but this is the lurking accuracy bug for any
-  future support of 18-decimal ERC-20s.
-- **Safe protocol-kit v7 migration.** PR #58 is blocked until
-  `safe.service.ts` migrates away from `SafeFactory` and adopts the
-  current v7 deployment/init API.
-- **TypeScript 6 adoption.** PR #64 is blocked until
-  `openapi-typescript` supports TypeScript 6 or the spec-generation
-  dependency path changes.
+- `docker compose -f docker-compose.dev.yml up --build`
+- `npm run smoke:dev` against a running dev stack
+- `node examples/a2a-collab/index.mjs`
+- `node examples/swap-planner/index.mjs`
+- `node examples/delegation-chain/index.mjs`
+
+Reason: Docker Desktop was not running on this Windows machine:
+
+```text
+failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
+```
+
+CI did validate the backend/E2E paths with Postgres/Redis services for the merged PRs, but the first-run Docker quickstart remains a manual validation debt.
 
 ---
 
-## Conventions reaffirmed this session
+## Current P0s
 
-- **NULL ≠ 0 in financial columns.** When a sentinel value (`'0'`,
-  `''`, `0n`) is forced to mean both "real zero" and "unresolved", you
-  get silent data corruption that's invisible until a downstream
-  consumer (dashboard, accounting) misreports something. Use NULL +
-  a `resolved` boolean wrapper. The whole #90 story is a worked
-  example.
-- **Persist USD value at the moment of the event, not at the moment of
-  query.** Same lesson as fee.service already learned — historical
-  values must be locked, not re-derived against current market data.
-- **Hoisted env stubs in unit tests.** `vi.hoisted` to set the env
-  vars `config/env.ts` requires lets the suite run cleanly outside
-  CI. Pattern is in `ens.service.test.ts` and now `pnl.service.test.ts`
-  + `payment-finalizer.snapshot.test.ts`.
-- **`prisma generate` will silently bump `@prisma/client` and
-  `prisma` versions in `package.json`/`package-lock.json`.** Always
-  diff before committing. (Caught and reverted this session.)
+1. **Run the first-run validation on a machine with Docker available.**
+
+   ```bash
+   docker compose -f docker-compose.dev.yml up --build
+   npm run smoke:dev
+   node examples/a2a-collab/index.mjs
+   node examples/swap-planner/index.mjs
+   node examples/delegation-chain/index.mjs
+   ```
+
+2. **If any first-run step fails, fix that before building new features.**
+
+3. **Record the result in this file and `HANDOFF.md`.**
 
 ---
 
-*Last touch: 2026-05-07 (autonomous session). Replace this header with
-the new session date when you update.*
+## Next non-P0 technical work
+
+Only after first-run validation is clean:
+
+- Token registry / decimals lookup for non-ETH rewards. This reduces accounting error risk from the current 6-decimal MVP assumption.
+- Setup-checklist review for `WALLET_PROVIDER=local` and dev-vs-prod credential paths.
+- Demo screencast using Claude Desktop + AgentFi MCP.
+
+Large roadmap work such as GMX/perps, escrow v3, and revenue sharing should still wait for a concrete user/integration signal.
+
+---
+
+_Last touch: 2026-05-08 (P0 diagnostic session)._

--- a/STATE.md
+++ b/STATE.md
@@ -1,9 +1,9 @@
 # AgentFi — Project State
 
-> **Read together with [VISION.md](VISION.md) (the *why*) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
-> This file is the **comprehensive, point-in-time snapshot** of what the project *is* today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
+> **Read together with [VISION.md](VISION.md) (the _why_) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
+> This file is the **comprehensive, point-in-time snapshot** of what the project _is_ today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: April 2026 · **main SHA** `084a086` · **npm** `@agent_fi/mcp-server@0.3.0`
+**Last updated**: May 2026 · **main SHA** `81c778c` · **npm** `@agent_fi/mcp-server@0.3.0`
 
 ---
 
@@ -13,11 +13,11 @@ AgentFi is the **economic infrastructure for non-human intelligence**. Open-sour
 
 **The thesis** (from VISION.md):
 
-- AI agents today *plan* transactions and hand off to humans to click "approve" — they're advisors behind glass.
+- AI agents today _plan_ transactions and hand off to humans to click "approve" — they're advisors behind glass.
 - AgentFi removes the glass: each agent has an MPC wallet, an on-chain policy, and can execute transactions within auditable limits set by its operator.
 - DeFi is the entry point because it's the only economic system that doesn't require a passport. A smart contract checks if the transaction is valid, not who sent it.
 - The real goal is the **agent-to-agent economy** — agents paying each other for data, compute, coordination, services, at machine speed. The volume is expected to eclipse human-to-human economic activity the same way algorithmic trading eclipsed human day-trading.
-- **Self-sustaining agents**: the moment an agent's earnings exceed its costs, it has crossed a line no AI system has crossed before — the transition from *tool* to *participant*.
+- **Self-sustaining agents**: the moment an agent's earnings exceed its costs, it has crossed a line no AI system has crossed before — the transition from _tool_ to _participant_.
 
 **Revenue model**: on-chain basis-point fee, collected atomically when transactions flow through `AgentExecutor`. Not SaaS. Scales linearly with A2A volume with no invoicing layer.
 
@@ -50,40 +50,40 @@ AgentFi is the **economic infrastructure for non-human intelligence**. Open-sour
 
 ### Tech choices
 
-| Layer | Stack | Why |
-|---|---|---|
-| L1 | Turnkey MPC + Safe SDK | MPC splits keys across shards that never reunite; Safe allows modules that enforce policy on-chain |
-| L2 | Solidity 0.8.24 + Foundry | Policy module validates each tx before Safe executes; Executor batches and collects fee in the same transaction |
-| L3 | Node 22 + Fastify 5 + Prisma 5 + Zod + viem 2 (ethers 5 kept only for Safe SDK compat) | Type-safe API, runtime validation, RPC fallback, decoupled workers |
-| L3 queues | BullMQ on Redis | Async tx pipeline, retries, DLQ, daily reputation cron |
-| L3 DB | PostgreSQL 15 via Prisma 5 | Relational graph of Agent ↔ Jobs ↔ Transactions ↔ FeeEvents ↔ DailyVolume |
-| L4 | @modelcontextprotocol/sdk + openapi-typescript | MCP standard interface; types generated from OpenAPI spec |
-| Infra | Dockerfiles (3) + `nixpacks.toml` + `railway.json` | Reproducible builds, provider-agnostic deploy |
-| CI | GitHub Actions (6 jobs, 5 required + OpenAPI Spec) | Type-check, unit tests, integration E2E (Anvil + PG + Redis), Forge tests, OpenAPI drift guard |
-| Test | Vitest + Forge | Unit (mocks), E2E (real Anvil), contract |
+| Layer     | Stack                                                                                  | Why                                                                                                             |
+| --------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| L1        | Turnkey MPC + Safe SDK                                                                 | MPC splits keys across shards that never reunite; Safe allows modules that enforce policy on-chain              |
+| L2        | Solidity 0.8.24 + Foundry                                                              | Policy module validates each tx before Safe executes; Executor batches and collects fee in the same transaction |
+| L3        | Node 22 + Fastify 5 + Prisma 5 + Zod + viem 2 (ethers 5 still used by Aave helpers)    | Type-safe API, runtime validation, RPC fallback, decoupled workers                                              |
+| L3 queues | BullMQ on Redis                                                                        | Async tx pipeline, retries, DLQ, daily reputation cron                                                          |
+| L3 DB     | PostgreSQL 15 via Prisma 5                                                             | Relational graph of Agent ↔ Jobs ↔ Transactions ↔ FeeEvents ↔ DailyVolume                                       |
+| L4        | @modelcontextprotocol/sdk + openapi-typescript                                         | MCP standard interface; types generated from OpenAPI spec                                                       |
+| Infra     | Dockerfiles (3) + `nixpacks.toml` + `railway.json`                                     | Reproducible builds, provider-agnostic deploy                                                                   |
+| CI        | GitHub Actions (6 jobs, 5 required + OpenAPI Spec)                                     | Type-check, unit tests, integration E2E (Anvil + PG + Redis), Forge tests, OpenAPI drift guard                  |
+| Test      | Vitest + Forge                                                                         | Unit (mocks), E2E (real Anvil), contract                                                                        |
 
 ### External dependencies (configured by the operator)
 
-| Service | Role | Alternatives |
-|---|---|---|
-| Alchemy | RPC for Ethereum / Base / Arbitrum / Polygon | Infura, QuickNode, Ankr |
-| Turnkey | MPC wallet provisioning + signing | — (AWS KMS would work but trades MPC for single root) |
-| Tenderly | Pre-broadcast transaction simulation | Optional — graceful fallback if unset |
-| PostgreSQL | Persistence | Neon, Supabase, Railway PG, self-host |
-| Redis | BullMQ queues + rate limit + sim cache | Upstash, Railway Redis |
-| Stripe | Subscriptions (PRO tier) | Optional — only needed if running paid SaaS |
-| ENS | Persistent on-chain identity | Optional — agents work without it |
+| Service    | Role                                         | Alternatives                                          |
+| ---------- | -------------------------------------------- | ----------------------------------------------------- |
+| Alchemy    | RPC for Ethereum / Base / Arbitrum / Polygon | Infura, QuickNode, Ankr                               |
+| Turnkey    | MPC wallet provisioning + signing            | — (AWS KMS would work but trades MPC for single root) |
+| Tenderly   | Pre-broadcast transaction simulation         | Optional — graceful fallback if unset                 |
+| PostgreSQL | Persistence                                  | Neon, Supabase, Railway PG, self-host                 |
+| Redis      | BullMQ queues + rate limit + sim cache       | Upstash, Railway Redis                                |
+| Stripe     | Subscriptions (PRO tier)                     | Optional — only needed if running paid SaaS           |
+| ENS        | Persistent on-chain identity                 | Optional — agents work without it                     |
 
 ---
 
 ## 3. Supported Networks
 
-| Chain | ID | Supported Protocols |
-|-------|----|---------------------|
-| Ethereum Mainnet | 1 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 |
-| Base | 8453 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (**contracts deployed**) |
-| Arbitrum One | 42161 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 |
-| Polygon | 137 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 |
+| Chain            | ID    | Supported Protocols                                                                   |
+| ---------------- | ----- | ------------------------------------------------------------------------------------- |
+| Ethereum Mainnet | 1     | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626                          |
+| Base             | 8453  | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626 (**contracts deployed**) |
+| Arbitrum One     | 42161 | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626                          |
+| Polygon          | 137   | Uniswap V3, Aave V3, Compound V3, Curve StableSwap, ERC-4626                          |
 
 **Base Mainnet** is the only chain with contracts deployed by the maintainers:
 
@@ -98,39 +98,39 @@ Self-hosted operators can reuse these addresses (in which case the protocol fee 
 
 ### 4.1 Core DeFi primitives
 
-| Action | Endpoint | MCP tool | Notes |
-|---|---|---|---|
-| Swap (Uniswap V3) | `POST /v1/transactions/swap` | `execute_swap` | Router calldata + Tenderly simulation + Executor → on-chain fee |
-| Swap (Curve StableSwap) | `POST /v1/transactions/swap-curve` | `swap_curve` | `exchange(i, j, dx, minDy)` on classic Curve pools |
-| Transfer | `POST /v1/transactions/transfer` | `send_transfer` | ETH or ERC-20, validated against policy allowlist |
-| Supply Aave V3 | `POST /v1/transactions/supply` | `supply_aave` | `supply()` on the Aave Pool |
-| Withdraw Aave | `POST /v1/transactions/withdraw` | `withdraw_aave` | `withdraw()` from the Aave Pool |
-| Supply Compound V3 | `POST /v1/transactions/supply-compound` | `supply_compound` | `supply()` on the Comet USDC market |
-| Withdraw Compound | `POST /v1/transactions/withdraw-compound` | `withdraw_compound` | `withdraw()` from Comet |
-| Deposit ERC-4626 | `POST /v1/transactions/deposit-erc4626` | `deposit_erc4626` | Any compliant vault (Yearn, Morpho, Beefy, Gearbox) |
-| Withdraw ERC-4626 | `POST /v1/transactions/withdraw-erc4626` | `withdraw_erc4626` | `withdraw(assets)` or `redeem(shares)` |
-| Balance query | `GET /v1/wallets/balances` | `get_balances` | ETH + known ERC-20 tokens, per chain |
+| Action                  | Endpoint                                  | MCP tool            | Notes                                                           |
+| ----------------------- | ----------------------------------------- | ------------------- | --------------------------------------------------------------- |
+| Swap (Uniswap V3)       | `POST /v1/transactions/swap`              | `execute_swap`      | Router calldata + Tenderly simulation + Executor → on-chain fee |
+| Swap (Curve StableSwap) | `POST /v1/transactions/swap-curve`        | `swap_curve`        | `exchange(i, j, dx, minDy)` on classic Curve pools              |
+| Transfer                | `POST /v1/transactions/transfer`          | `send_transfer`     | ETH or ERC-20, validated against policy allowlist               |
+| Supply Aave V3          | `POST /v1/transactions/supply`            | `supply_aave`       | `supply()` on the Aave Pool                                     |
+| Withdraw Aave           | `POST /v1/transactions/withdraw`          | `withdraw_aave`     | `withdraw()` from the Aave Pool                                 |
+| Supply Compound V3      | `POST /v1/transactions/supply-compound`   | `supply_compound`   | `supply()` on the Comet USDC market                             |
+| Withdraw Compound       | `POST /v1/transactions/withdraw-compound` | `withdraw_compound` | `withdraw()` from Comet                                         |
+| Deposit ERC-4626        | `POST /v1/transactions/deposit-erc4626`   | `deposit_erc4626`   | Any compliant vault (Yearn, Morpho, Beefy, Gearbox)             |
+| Withdraw ERC-4626       | `POST /v1/transactions/withdraw-erc4626`  | `withdraw_erc4626`  | `withdraw(assets)` or `redeem(shares)`                          |
+| Balance query           | `GET /v1/wallets/balances`                | `get_balances`      | ETH + known ERC-20 tokens, per chain                            |
 
 ### 4.2 Agent-to-Agent economy (the heart of the thesis)
 
-| Action | Endpoint | MCP tool | Notes |
-|---|---|---|---|
-| Publish service | `PATCH /v1/agents/me/manifest` | `update_manifest` | JSON of skills and pricing the agent offers peers |
-| Discover agents | `GET /v1/agents/search?q=...` | `search_agents` | Full-text search on manifest + reputation score |
-| Create job | `POST /v1/jobs` | `create_job` | Requester publishes task + reward; **escrow v2** commits USD volume atomically |
-| Accept job | `PATCH /v1/jobs/:id` (status=ACCEPTED) | `accept_job` | Provider signals commitment |
-| Complete job | `PATCH /v1/jobs/:id` (status=COMPLETED) | `complete_job` | Provider attaches result; **payment auto-triggered** via `executeA2APayment()` — same policy + simulation + fee pipeline as any public tx |
-| Cancel / fail | `PATCH /v1/jobs/:id` (status=CANCELLED/FAILED) | `cancel_job` | Escrow releases daily volume credit |
-| Trust report | `GET /v1/agents/:id/trust-report` | `get_trust_report` | Reputation score (0–10 000) + A2A tx count |
+| Action          | Endpoint                                       | MCP tool           | Notes                                                                                                                                     |
+| --------------- | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Publish service | `PATCH /v1/agents/me/manifest`                 | `update_manifest`  | JSON of skills and pricing the agent offers peers                                                                                         |
+| Discover agents | `GET /v1/agents/search?q=...`                  | `search_agents`    | Full-text search on manifest + reputation score                                                                                           |
+| Create job      | `POST /v1/jobs`                                | `create_job`       | Requester publishes task + reward; **escrow v2** commits USD volume atomically                                                            |
+| Accept job      | `PATCH /v1/jobs/:id` (status=ACCEPTED)         | `accept_job`       | Provider signals commitment                                                                                                               |
+| Complete job    | `PATCH /v1/jobs/:id` (status=COMPLETED)        | `complete_job`     | Provider attaches result; **payment auto-triggered** via `executeA2APayment()` — same policy + simulation + fee pipeline as any public tx |
+| Cancel / fail   | `PATCH /v1/jobs/:id` (status=CANCELLED/FAILED) | `cancel_job`       | Escrow releases daily volume credit                                                                                                       |
+| Trust report    | `GET /v1/agents/:id/trust-report`              | `get_trust_report` | Reputation score (0–10 000) + A2A tx count                                                                                                |
 
 ### 4.3 Policy and governance
 
-| Action | Endpoint | Notes |
-|---|---|---|
-| Register agent | `POST /v1/agents` | Creates Turnkey wallet → Safe Smart Wallet → initial `AgentPolicy` → optional ENS subdomain |
+| Action           | Endpoint                     | Notes                                                                                         |
+| ---------------- | ---------------------------- | --------------------------------------------------------------------------------------------- |
+| Register agent   | `POST /v1/agents`            | Creates Turnkey wallet → Safe Smart Wallet → initial `AgentPolicy` → optional ENS subdomain   |
 | Configure policy | `PATCH /v1/agents/me/policy` | Off-chain limits: `maxValuePerTx`, `allowedContracts`, `cooldownSeconds`, `maxDailyVolumeUsd` |
-| Kill switch | `DELETE /v1/agents/:id` | Soft-deactivate + emergency pause |
-| Billing view | `GET /v1/agents/me/billing` | Fees paid, tx count this period, subscription tier |
+| Kill switch      | `DELETE /v1/agents/:id`      | Soft-deactivate + emergency pause                                                             |
+| Billing view     | `GET /v1/agents/me/billing`  | Fees paid, tx count this period, subscription tier                                            |
 
 Policy enforces in **two layers** on purpose:
 
@@ -141,21 +141,21 @@ Even if the backend is compromised, the Safe will refuse transactions that viola
 
 ### 4.4 Self-sustaining agents (Phase 4)
 
-| Action | Endpoint | Notes |
-|---|---|---|
-| P&L dashboard | `GET /v1/agents/me/pnl` | Profit / loss: earnings (A2A rewards received) vs costs (protocol fees + rewards paid + **gas**, computed as `gasUsed × effectiveGasPriceWei`) |
-| ENS identity | auto on register when `ENS_PARENT_DOMAIN` is set | Agent gets `alice-abc123.agentfi.eth` pointing to its Safe address — referenceable by other dApps, explorers, peer agents |
-| Reputation auto-recompute | `POST /admin/reputation/recompute` + daily cron at 02:00 UTC | Score 0–10 000 from: tx success (40%) + job completion (30%) + volume (20%) + consistency (10%), with 2× weight on the last 30 days |
+| Action                    | Endpoint                                                     | Notes                                                                                                                                          |
+| ------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| P&L dashboard             | `GET /v1/agents/me/pnl`                                      | Profit / loss: earnings (A2A rewards received) vs costs (protocol fees + rewards paid + **gas**, computed as `gasUsed × effectiveGasPriceWei`) |
+| ENS identity              | auto on register when `ENS_PARENT_DOMAIN` is set             | Agent gets `alice-abc123.agentfi.eth` pointing to its Safe address — referenceable by other dApps, explorers, peer agents                      |
+| Reputation auto-recompute | `POST /admin/reputation/recompute` + daily cron at 02:00 UTC | Score 0–10 000 from: tx success (40%) + job completion (30%) + volume (20%) + consistency (10%), with 2× weight on the last 30 days            |
 
 ### 4.5 Operator admin
 
-| Endpoint | Purpose |
-|---|---|
-| `GET /admin/agents` | List all + reputation drift |
-| `GET /admin/revenue` | Fees accumulated by tier |
+| Endpoint                           | Purpose                            |
+| ---------------------------------- | ---------------------------------- |
+| `GET /admin/agents`                | List all + reputation drift        |
+| `GET /admin/revenue`               | Fees accumulated by tier           |
 | `POST /admin/reputation/recompute` | Force recompute (one agent or all) |
-| `GET /admin/agents/:id/pnl` | P&L for any agent |
-| `POST /admin/agents/:id/pause` | Individual kill switch |
+| `GET /admin/agents/:id/pnl`        | P&L for any agent                  |
+| `POST /admin/agents/:id/pause`     | Individual kill switch             |
 
 Auth via `x-admin-secret` header with anti-brute-force lockout (30-min cooldown after 5 failed attempts in 10 minutes).
 
@@ -170,7 +170,7 @@ Example: an agent swaps 0.1 ETH to USDC on Base.
 3. Backend validates request (Zod) and resolves `Agent` by `apiKeyHash` (bcrypt).
 4. **Off-chain policy check** (`PolicyService`) — active? kill switch? `maxValuePerTxEth`? contract allowlisted? cooldown elapsed? daily-volume ceiling (atomic raw SQL)? If any fails, 403.
 5. `TransactionBuilder` builds Uniswap V3 router calldata via viem + SDK.
-6. `SimulatorService` runs Tenderly — if it would revert, returns 400 with the reason *without spending gas*.
+6. `SimulatorService` runs Tenderly — if it would revert, returns 400 with the reason _without spending gas_.
 7. DB inserts a `Transaction` row with status `QUEUED`.
 8. Job is enqueued in the BullMQ `transactions` queue.
 9. API returns `{ transactionId, status: QUEUED }` immediately.
@@ -187,42 +187,42 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 
 ## 6. Phase progress
 
-| Phase | Theme | Progress | Status |
-|---|---|---|---|
-| **1 — Bootstrap** | Registry, wallets, basic swap | 100% | Shipped |
-| **2 — HITL + Transparency** | Policy, kill switch, audit log | 100% | Shipped |
-| **2.5 — Go-Live Hardening** | Security, CI 6/6, Next.js 16, Fastify 5, npm audit zero-HIGH | 100% | Shipped |
-| **3 — A2A Economy + DeFi expansion** | Jobs, escrow, reputation, Compound V3 / ERC-4626 / Curve | **~88%** | Remaining: GMX adapter, escrow v3 (on-chain), sign/verify-handshake (Turnkey-blocked) |
-| **4 — Self-Sustaining Agents** | P&L, identity, self-funding, revenue share | **~40%** | Shipped: P&L v1 + v2 (with gas), ENS identity. Remaining: self-funding (legal decision), revenue sharing |
-| **5 — Adoption model evolution** | SaaS-as-a-service pricing | 0% | Not started |
-| **6 — Frontier** | Agent-to-agent economy at scale | 0% | Not started |
+| Phase                                | Theme                                                               | Progress | Status                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| **1 — Bootstrap**                    | Registry, wallets, basic swap                                       | 100%     | Shipped                                                                                                  |
+| **2 — HITL + Transparency**          | Policy, kill switch, audit log                                      | 100%     | Shipped                                                                                                  |
+| **2.5 — Go-Live Hardening**          | Security, CI 6/6, Next.js 16, Fastify 5, npm audit zero-HIGH        | 100%     | Shipped                                                                                                  |
+| **3 — A2A Economy + DeFi expansion** | Jobs, escrow, reputation, handshake, Compound V3 / ERC-4626 / Curve | **~90%** | Remaining: GMX adapter, escrow v3 (on-chain)                                                             |
+| **4 — Self-Sustaining Agents**       | P&L, identity, self-funding, revenue share                          | **~40%** | Shipped: P&L v1 + v2 (with gas), ENS identity. Remaining: self-funding (legal decision), revenue sharing |
+| **5 — Adoption model evolution**     | SaaS-as-a-service pricing                                           | 0%       | Not started                                                                                              |
+| **6 — Frontier**                     | Agent-to-agent economy at scale                                     | 0%       | Not started                                                                                              |
 
 ---
 
 ## 7. Public artifacts
 
-| Artifact | URL | Status |
-|---|---|---|
-| Source code | https://github.com/felippeyann/agentfi | Apache 2.0, public |
-| Release | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0 | v0.1.0 (April 2026) |
-| mcp-server npm | https://www.npmjs.com/package/@agent_fi/mcp-server | **v0.3.0** (breaking: `request_policy_update` → `update_policy`) |
-| mcp-server releases | https://github.com/felippeyann/agentfi/releases | v0.1.0, v0.2.0, v0.3.0 all published |
-| mcp.so listing | https://mcp.so/server/agentfi-mcp-server/felippeyann | submitted (pending review) |
-| awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091 | open (pending maintainer merge) |
-| Base contracts | `0x03af…6A6d` + `0x5441…24b3` | verified on Basescan |
-| OpenAPI spec | `docs/api/openapi.yaml` | 3.0.3, clean under Redocly lint |
-| Brand avatar | `.github/avatar.svg` | live |
-| Dev quickstart | [`docs/dev-quickstart.md`](docs/dev-quickstart.md) + `docker-compose.dev.yml` | zero-credential stack, ~3 min boot |
-| Examples (runnable) | [`examples/a2a-collab`](examples/a2a-collab), [`examples/swap-planner`](examples/swap-planner), [`examples/delegation-chain`](examples/delegation-chain) | zero-dep Node scripts |
-| Staging demo | https://agentfi-develop.up.railway.app | Running, **no SLA** |
-| Docs set | `VISION.md`, `STATE.md`, `HANDOFF.md`, `docs/` | live (archive in `docs/_archive/`) |
+| Artifact               | URL                                                                                                                                                      | Status                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Source code            | https://github.com/felippeyann/agentfi                                                                                                                   | Apache 2.0, public                                                      |
+| Release                | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0                                                                                               | v0.1.0 (April 2026)                                                     |
+| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.3.0** (breaking: `request_policy_update` → `update_policy`)        |
+| mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0 all published                                    |
+| mcp.so listing         | https://mcp.so/server/agentfi-mcp-server/felippeyann                                                                                                     | submitted (pending review)                                              |
+| awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091                                                                                                | open (pending maintainer merge)                                         |
+| Base contracts         | `0x03af…6A6d` + `0x5441…24b3`                                                                                                                            | verified on Basescan                                                    |
+| OpenAPI spec           | `docs/api/openapi.yaml`                                                                                                                                  | 3.0.3, clean under Redocly lint                                         |
+| Brand avatar           | `.github/avatar.svg`                                                                                                                                     | live                                                                    |
+| Dev quickstart         | [`docs/dev-quickstart.md`](docs/dev-quickstart.md) + `docker-compose.dev.yml` + `npm run smoke:dev`                                                      | zero-credential stack, ~3 min boot, smoke path for first-run validation |
+| Examples (runnable)    | [`examples/a2a-collab`](examples/a2a-collab), [`examples/swap-planner`](examples/swap-planner), [`examples/delegation-chain`](examples/delegation-chain) | zero-dep Node scripts                                                   |
+| Staging demo           | https://agentfi-develop.up.railway.app                                                                                                                   | Running, **no SLA**                                                     |
+| Docs set               | `VISION.md`, `STATE.md`, `HANDOFF.md`, `docs/`                                                                                                           | live (archive in `docs/_archive/`)                                      |
 
 ---
 
-## 8. What does *not* exist (on purpose)
+## 8. What does _not_ exist (on purpose)
 
 - **Canonical hosted production** — would violate the "commons, fork it" principle. Only the no-SLA staging exists.
-- **Landing page / marketing surface** — AgentFi is infrastructure, not a product. Stripe integration is there only so self-hosting operators can charge subscriptions of their *own* if they want.
+- **Landing page / marketing surface** — AgentFi is infrastructure, not a product. Stripe integration is there only so self-hosting operators can charge subscriptions of their _own_ if they want.
 - **Closed-source features** — zero paywalls on core functionality.
 - **Centralized custody** — Turnkey MPC guarantees even the maintainer cannot move agent funds.
 - **Legal personhood wrapper** — explicitly called out in VISION.md as a non-technical problem. Liability sits with the human operator for V1.
@@ -231,6 +231,7 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 
 ## 9. Current pending work (details in HANDOFF.md)
 
+- **Verify dev stack + examples end-to-end** (`docker compose -f docker-compose.dev.yml up --build`, `npm run smoke:dev`, then all three `examples/*`) — local Docker was unavailable in the latest session, so CI is green but first-run manual validation is still owed.
 - **GMX / Perp adapter** (Phase 3 close)
 - **On-chain escrow v3** (Phase 3, requires Safe module deploy + audit prep)
 - **Self-funding sub-wallets** (Phase 4, blocked on legal structure decision)
@@ -240,9 +241,8 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 
 **Externally blocked:**
 
-- `sign-handshake` / `verify-handshake` — depends on Turnkey message-signing API scope
 - Legal personhood — society-wide, not this repo
 
 ---
 
-*This document is part of the required-reading set for any agent or human resuming work on the project. When scope, architecture, or phase progress changes, update it here.*
+_This document is part of the required-reading set for any agent or human resuming work on the project. When scope, architecture, or phase progress changes, update it here._

--- a/docs/dev-quickstart.md
+++ b/docs/dev-quickstart.md
@@ -38,13 +38,13 @@ api-1  | [warn] [local-wallet] LocalWalletService active — keys in process mem
 
 ## What's running
 
-| Service | Port | Purpose |
-|---|---|---|
-| API | 3000 | REST + MCP (`/mcp/sse`) |
-| Admin dashboard | 3001 | Next.js UI (login: `admin` / `admin`) |
-| MCP server (SSE) | 3002 | Standalone MCP transport |
-| Postgres | 5432 | `agentfi` / `agentfi` / `agentfi` |
-| Redis | 6379 | No password |
+| Service          | Port | Purpose                               |
+| ---------------- | ---- | ------------------------------------- |
+| API              | 3000 | REST + MCP (`/mcp/sse`)               |
+| Admin dashboard  | 3001 | Next.js UI (login: `admin` / `admin`) |
+| MCP server (SSE) | 3002 | Standalone MCP transport              |
+| Postgres         | 5432 | `agentfi` / `agentfi` / `agentfi`     |
+| Redis            | 6379 | No password                           |
 
 The dev stack is **zero-credential** — it sets `WALLET_PROVIDER=local`, which uses in-memory viem keys instead of Turnkey. **Keys are lost on every restart** by design, so you can never accidentally persist dev keys to production.
 
@@ -96,6 +96,16 @@ curl http://localhost:3000/health/ready
 curl http://localhost:3000/v1/agents/me \
   -H "x-api-key: agfi_live_..."
 ```
+
+Or run the versioned smoke test:
+
+```bash
+npm run smoke:dev
+```
+
+It registers two local agents, publishes a manifest, discovers the provider,
+creates and completes a no-reward A2A job, then reads trust + P&L. This path is
+designed to work on the zero-credential dev stack.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "agentfi",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felippeyann/agentfi.git"
+  },
   "private": true,
   "workspaces": [
     "packages/*"
@@ -13,6 +16,7 @@
     "lint": "npm run lint --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "smoke:dev": "node scripts/smoke-dev.mjs",
     "preflight": "tsx scripts/preflight.ts",
     "release:v1:check": "node scripts/release-v1.mjs check",
     "release:v1:tag": "node scripts/release-v1.mjs tag",

--- a/scripts/smoke-dev.mjs
+++ b/scripts/smoke-dev.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Minimal first-run smoke test for the zero-credential dev stack.
+ *
+ * Requires the stack from docker-compose.dev.yml to be running:
+ *   docker compose -f docker-compose.dev.yml up --build
+ *
+ * Then run:
+ *   npm run smoke:dev
+ */
+
+const API_URL = process.env.AGENTFI_API_URL ?? 'http://localhost:3000';
+const OPERATOR_SECRET =
+  process.env.AGENTFI_OPERATOR_SECRET ?? 'dev-api-secret-min-32-chars-long-xxxxx';
+
+async function api(path, options = {}) {
+  const res = await fetch(`${API_URL}${path}`, {
+    ...options,
+    headers: {
+      'content-type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+  });
+
+  const text = await res.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+
+  if (!res.ok) {
+    const detail = typeof body === 'string' ? body : JSON.stringify(body);
+    throw new Error(`${options.method ?? 'GET'} ${path} -> ${res.status}: ${detail}`);
+  }
+
+  return body;
+}
+
+function step(label, message) {
+  console.log(`\x1b[36m[${label}]\x1b[0m ${message}`);
+}
+
+async function requireApi() {
+  try {
+    await api('/health');
+  } catch (err) {
+    throw new Error(
+      `AgentFi API is not reachable at ${API_URL}. ` +
+        'Start it with `docker compose -f docker-compose.dev.yml up --build` first. ' +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function registerAgent(name) {
+  return api('/v1/agents', {
+    method: 'POST',
+    headers: { 'x-api-key': OPERATOR_SECRET },
+    body: JSON.stringify({ name, chainIds: [1], tier: 'FREE' }),
+  });
+}
+
+async function publishManifest(apiKey, manifest) {
+  return api('/v1/agents/me/manifest', {
+    method: 'PATCH',
+    headers: { 'x-api-key': apiKey },
+    body: JSON.stringify({ manifest }),
+  });
+}
+
+async function createJob(apiKey, providerId, payload) {
+  return api('/v1/jobs', {
+    method: 'POST',
+    headers: { 'x-api-key': apiKey },
+    body: JSON.stringify({ providerId, payload }),
+  });
+}
+
+async function patchJob(apiKey, jobId, update) {
+  return api(`/v1/jobs/${jobId}`, {
+    method: 'PATCH',
+    headers: { 'x-api-key': apiKey },
+    body: JSON.stringify(update),
+  });
+}
+
+async function main() {
+  step('env', `API_URL = ${API_URL}`);
+
+  step('1', 'Check API health');
+  await requireApi();
+
+  step('2', 'Register provider and requester agents');
+  const suffix = Date.now();
+  const provider = await registerAgent(`smoke-provider-${suffix}`);
+  const requester = await registerAgent(`smoke-requester-${suffix}`);
+
+  step('3', 'Verify authenticated agent lookup');
+  const requesterMe = await api('/v1/agents/me', {
+    headers: { 'x-api-key': requester.apiKey },
+  });
+  if (requesterMe.id !== requester.id) {
+    throw new Error(`Expected requester /me id ${requester.id}, got ${requesterMe.id}`);
+  }
+
+  step('4', 'Publish provider manifest and discover it by name');
+  await publishManifest(provider.apiKey, {
+    services: [{ name: 'smoke-analysis', description: 'Dev-stack smoke service' }],
+  });
+  const search = await api(`/v1/agents/search?q=${encodeURIComponent(`smoke-provider-${suffix}`)}`);
+  if (!Array.isArray(search.agents) || !search.agents.some((agent) => agent.id === provider.id)) {
+    throw new Error('Provider was not returned by /v1/agents/search');
+  }
+
+  step('5', 'Create, accept, and complete a no-reward A2A job');
+  const job = await createJob(requester.apiKey, provider.id, {
+    task: 'smoke-analysis',
+    input: 'dev-stack',
+  });
+  await patchJob(provider.apiKey, job.id, { status: 'ACCEPTED' });
+  await patchJob(provider.apiKey, job.id, {
+    status: 'COMPLETED',
+    result: { ok: true, source: 'smoke-dev' },
+  });
+
+  step('6', 'Read provider trust and requester P&L');
+  const [trust, pnl] = await Promise.all([
+    api(`/v1/agents/${provider.id}/trust-report`),
+    api('/v1/agents/me/pnl', { headers: { 'x-api-key': requester.apiKey } }),
+  ]);
+  if (!trust.id || pnl.netPnlUsd === undefined) {
+    throw new Error('Expected trust report and P&L response shapes');
+  }
+
+  console.log('\n\x1b[32m✓ Dev smoke completed.\x1b[0m');
+  console.log(`provider=${provider.id}`);
+  console.log(`requester=${requester.id}`);
+  console.log(`job=${job.id}`);
+}
+
+main().catch((err) => {
+  console.error('\n\x1b[31m✗ Dev smoke failed:\x1b[0m', err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add npm run smoke:dev for zero-credential dev stack first-run validation
- document the smoke path in the dev quickstart
- refresh STATE/HANDOFF/SESSION_NOTES after #58 and #64 were merged

## Validation
- node --check scripts/smoke-dev.mjs
- npm run typecheck --workspaces --if-present
- git diff --check
- npm run smoke:dev currently fails locally with a clear message because Docker/API is not running on this machine
