### PR TITLE
fix: validate zero-credential dev stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Dev smoke test** — `npm run smoke:dev` runs a zero-dependency first-run validation against the local dev stack: health, agent registration, manifest publish, agent search, no-reward A2A job completion, trust report, and P&L response shape.
+
 - **A2A handshake — `sign_handshake` / `verify_handshake` implemented.** Closes steps 3–5 of [#49](https://github.com/felippeyann/agentfi/issues/49); previously both returned 501.
   - `POST /v1/agents/me/sign-handshake` now signs an arbitrary message with the agent's wallet via EIP-191 `personal_sign`. `LocalWalletService` uses viem's `signMessage`; `TurnkeyService` uses `signRawPayload` with `HASH_FUNCTION_NO_OP` after pre-hashing with viem's `hashMessage`, then assembles a standard 65-byte r‖s‖v signature.
   - `POST /v1/agents/verify-handshake` (public) accepts `{ message, signature, address }` or `{ message, signature, agentId }`. Tries ECDSA recovery first (works for EOA); falls back to EIP-1271 via the chain's public client for contract wallets (Safe). Returns `{ valid, address, verifiedVia: 'ecdsa' | 'eip1271' }`.
@@ -29,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`STATE.md`** at the repo root — comprehensive, point-in-time project state (purpose, stack, capabilities, phase progress). Sits between VISION.md (the _why_) and HANDOFF.md (live tasks) as required reading.
 - **README.md** refreshed to reflect shipped work: ENS identity, OpenAPI spec, mcp-server v0.2.0 on npm, P&L v2 with gas costs. Getting-Started-for-Operators section now points at the provider-agnostic deployment guide.
 - **HANDOFF.md** "Files to Read First" ordering updated to include STATE.md.
+
+### Fixed
+
+- **Zero-credential Docker first-run path** — fresh `docker compose -f docker-compose.dev.yml up --build` now boots all five services healthy and passes `npm run smoke:dev` plus the three example scripts.
+  - API dev compose runs `prisma migrate deploy` before Fastify starts, so a clean Postgres volume has the required tables.
+  - Docker healthchecks use `127.0.0.1` to avoid Alpine resolving `localhost` to IPv6 `::1` when services listen on IPv4.
+  - Admin Docker image sets `HOSTNAME=0.0.0.0` so Next standalone is reachable inside the container and through host port mapping.
+  - MCP Docker image copies workspace-local `packages/mcp-server/node_modules`, fixing TypeScript 6 builds that could not resolve `dotenv/config`.
+  - Standalone MCP dev compose gets a placeholder `AGENTFI_API_KEY` so the SSE service can boot before a real agent key exists.
+- **Public discovery auth** — global agent-key middleware now skips the public routes already documented as unauthenticated: `/v1/agents/search`, `/v1/agents/:id/manifest`, `/v1/agents/:id/trust-report`, and `/v1/agents/verify-handshake`.
 
 ### Changed
 

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -16,13 +16,14 @@ RUN cd packages/admin && npm run build
 FROM base AS runner
 ENV NODE_ENV=production
 ENV PORT=3001
+ENV HOSTNAME=0.0.0.0
 WORKDIR /app
 COPY --from=builder /app/packages/admin/.next/standalone ./
 COPY --from=builder /app/packages/admin/.next/static ./packages/admin/.next/static
 COPY --from=builder /app/packages/admin/public ./packages/admin/public
 EXPOSE 3001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3001/health || exit 1
 RUN addgroup -g 1001 appuser && adduser -D -u 1001 -G appuser appuser
 USER appuser
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -45,7 +45,7 @@ COPY --from=builder /app/packages/backend/src/db/migrations ./src/db/migrations
 # PORT is injected by Fly.io (8080); fallback to API_PORT then 3000 for other hosts
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT:-3000}/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${PORT:-3000}/health || exit 1
 RUN addgroup -g 1001 appuser && adduser -D -u 1001 -G appuser appuser
 USER appuser
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -9,6 +9,7 @@ RUN npm ci --workspace=packages/mcp-server --include-workspace-root
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/mcp-server/node_modules ./packages/mcp-server/node_modules
 COPY tsconfig.base.json ./tsconfig.base.json
 COPY packages/mcp-server ./packages/mcp-server
 RUN cd packages/mcp-server && npm run build
@@ -18,9 +19,10 @@ ENV NODE_ENV=production
 WORKDIR /app/packages/mcp-server
 COPY --from=builder /app/packages/mcp-server/dist ./dist
 COPY --from=builder /app/node_modules ../../node_modules
+COPY --from=builder /app/packages/mcp-server/node_modules ./node_modules
 EXPOSE 3002
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3002/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3002/health || exit 1
 RUN addgroup -g 1001 appuser && adduser -D -u 1001 -G appuser appuser
 USER appuser
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For _what the project is_, read [STATE.md](STATE.md). For _why_, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: May 2026 · **main SHA** `81c778c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
+**Last updated**: May 2026 · **main SHA** `2b8a20b` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
 
 ---
 
@@ -74,7 +74,6 @@ Ranked by closure value, not effort.
 
 | Task                                                  | Phase  | Effort                     | Value                                                                                                                                                                                                                                     |
 | ----------------------------------------------------- | ------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Verify dev stack + smoke + 3 examples run end-to-end  | —      | ~20 min                    | **High** — CI-green ≠ functionally validated. Run `docker compose -f docker-compose.dev.yml up --build`, `npm run smoke:dev`, then the 3 `examples/*` scripts. Local Docker was unavailable in the latest session, so this is still owed. |
 | GMX / Perp adapter                                    | 3      | 10–20 h                    | Closes Phase 3 DeFi surface.                                                                                                                                                                                                              |
 | Escrow v3 on-chain (`EscrowModule.sol` + integration) | 3      | 30–40 h (incl. audit prep) | Closes Phase 3; funds un-spendable until terminal state.                                                                                                                                                                                  |
 | Revenue sharing (protocol ↔ self-hosted)              | 4      | Design + impl              | Aligns incentives per VISION.md.                                                                                                                                                                                                          |
@@ -179,7 +178,7 @@ Large features that were in the roadmap but had no external demand (GMX adapter,
 
 **The rule:** type-check + unit tests + CI passing does not mean the thing works end-to-end. Always run the happy path manually before shipping user-facing surface.
 
-**The evidence:** three `examples/*` scripts and `docker-compose.dev.yml` shipped across PRs #44–#47 all had green CI but were never actually run `docker compose up` → `node examples/…` by the shipping agent. This was flagged in the session review as validation debt. The next session still owes paying it.
+**The evidence:** three `examples/*` scripts and `docker-compose.dev.yml` shipped across PRs #44–#47 all had green CI but were not initially run `docker compose up` → `node examples/…` by the shipping agent. When the debt was paid later, first-run validation found real breakage: missing MCP workspace deps in the Docker image, missing API migrations on fresh Postgres, IPv6 `localhost` healthcheck mismatch, and public discovery routes blocked by auth.
 
 **How to apply:** for anything a new user or evaluator might run (examples, quickstarts, install commands), execute the full path locally at least once before merging. For backend-only changes, CI is usually sufficient.
 
@@ -254,15 +253,23 @@ embeds a versioned API URL), open one PR per repo and merge them in
 order. Don't re-attempt monorepo consolidation without explicit user
 agreement.
 
-### Validation debt from recent sessions
+### Dev-stack validation
 
-The three `examples/*` scripts and `docker-compose.dev.yml` passed typecheck/syntax/CI but still need a local first-run validation. A smoke helper now exists:
+The zero-credential dev stack has been validated locally from clean compose
+volumes. This path should be rerun before changing examples, Dockerfiles,
+`docker-compose.dev.yml`, auth middleware, Prisma migrations, or quickstart docs:
 
 ```bash
+docker compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.dev.yml up --build -d
 npm run smoke:dev
+node examples/a2a-collab/index.mjs
+node examples/swap-planner/index.mjs
+node examples/delegation-chain/index.mjs
 ```
 
-Before shipping new examples or touching the dev stack, run through the quickstart, `npm run smoke:dev`, and all three examples manually. If something breaks, fixing that comes first.
+Expected result: all five services healthy, smoke passes, and all three examples
+complete without external credentials.
 
 ---
 

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -9,7 +9,7 @@
 
 ## Where we are right now
 
-`main` and `develop` are aligned at `81c778c`.
+`main` and `develop` are aligned at `2b8a20b`.
 
 Open GitHub state after the dependency cleanup:
 
@@ -17,7 +17,7 @@ Open GitHub state after the dependency cleanup:
 | ----------------------------- | ------------------------------------- |
 | Open PRs                      | 0                                     |
 | Open issues                   | 0                                     |
-| Required CI                   | Green on latest merged dependency PRs |
+| Required CI                   | Green on latest merged PRs            |
 | Remaining Dependabot blockers | None                                  |
 
 The two previously blocked dependency PRs are closed:
@@ -84,6 +84,29 @@ The smoke test checks:
 - no-reward A2A job create/accept/complete
 - trust report and P&L response shapes
 
+### First-run Docker validation
+
+Docker Desktop was started locally and the first-run path was executed from a
+clean compose state (`docker compose down -v` before rebuild).
+
+Fixed blockers found during that validation:
+
+- `Dockerfile.mcp` now carries `packages/mcp-server/node_modules` into the
+  builder and runner stages so workspace-local dependencies such as
+  `dotenv/config` resolve under TypeScript 6.
+- `docker-compose.dev.yml` runs `prisma migrate deploy` before starting the API,
+  so a fresh Postgres volume has the schema before traffic reaches Fastify.
+- Docker healthchecks now use `127.0.0.1` instead of `localhost`, avoiding Alpine
+  `::1` resolution when services listen on IPv4.
+- The admin image sets `HOSTNAME=0.0.0.0`, so Next standalone is reachable by
+  the container healthcheck and host port mapping.
+- The standalone MCP SSE service gets a dev placeholder `AGENTFI_API_KEY` so it
+  can boot before a real agent key is registered.
+- Public discovery routes documented as unauthenticated
+  (`/v1/agents/search`, `/v1/agents/:id/manifest`,
+  `/v1/agents/:id/trust-report`, `/v1/agents/verify-handshake`) are now skipped
+  by the global agent-key middleware.
+
 ---
 
 ## Validation
@@ -95,47 +118,26 @@ Completed locally:
 - `npm run spec:check` passed.
 - `npm run spec:lint` passed.
 - `npm test -w packages/admin` passed.
-- Backend local test run reached 86/90; the remaining 4 need Postgres at `localhost:5432`.
-
-Not completed locally:
-
-- `docker compose -f docker-compose.dev.yml up --build`
-- `npm run smoke:dev` against a running dev stack
-- `node examples/a2a-collab/index.mjs`
-- `node examples/swap-planner/index.mjs`
-- `node examples/delegation-chain/index.mjs`
-
-Reason: Docker Desktop was not running on this Windows machine:
-
-```text
-failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
-```
-
-CI did validate the backend/E2E paths with Postgres/Redis services for the merged PRs, but the first-run Docker quickstart remains a manual validation debt.
+- `npm run test -w packages/backend` passed when pointed at the local compose
+  Postgres/Redis with required env vars set.
+- `docker compose -f docker-compose.dev.yml up --build -d` passed from clean
+  volumes.
+- All compose services reached healthy state: Postgres, Redis, API, admin, MCP.
+- `npm run smoke:dev` passed against the running dev stack.
+- `node examples/a2a-collab/index.mjs` passed.
+- `node examples/swap-planner/index.mjs` passed.
+- `node examples/delegation-chain/index.mjs` passed.
 
 ---
 
 ## Current P0s
 
-1. **Run the first-run validation on a machine with Docker available.**
-
-   ```bash
-   docker compose -f docker-compose.dev.yml up --build
-   npm run smoke:dev
-   node examples/a2a-collab/index.mjs
-   node examples/swap-planner/index.mjs
-   node examples/delegation-chain/index.mjs
-   ```
-
-2. **If any first-run step fails, fix that before building new features.**
-
-3. **Record the result in this file and `HANDOFF.md`.**
+No open P0 remains from the diagnostic pass. The dev-stack first-run path has
+now been executed and fixed locally.
 
 ---
 
 ## Next non-P0 technical work
-
-Only after first-run validation is clean:
 
 - Token registry / decimals lookup for non-ETH rewards. This reduces accounting error risk from the current 6-decimal MVP assumption.
 - Setup-checklist review for `WALLET_PROVIDER=local` and dev-vs-prod credential paths.

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the _why_) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project _is_ today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: May 2026 · **main SHA** `81c778c` · **npm** `@agent_fi/mcp-server@0.3.0`
+**Last updated**: May 2026 · **main SHA** `2b8a20b` · **npm** `@agent_fi/mcp-server@0.3.0`
 
 ---
 
@@ -212,7 +212,7 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 | Base contracts         | `0x03af…6A6d` + `0x5441…24b3`                                                                                                                            | verified on Basescan                                                    |
 | OpenAPI spec           | `docs/api/openapi.yaml`                                                                                                                                  | 3.0.3, clean under Redocly lint                                         |
 | Brand avatar           | `.github/avatar.svg`                                                                                                                                     | live                                                                    |
-| Dev quickstart         | [`docs/dev-quickstart.md`](docs/dev-quickstart.md) + `docker-compose.dev.yml` + `npm run smoke:dev`                                                      | zero-credential stack, ~3 min boot, smoke path for first-run validation |
+| Dev quickstart         | [`docs/dev-quickstart.md`](docs/dev-quickstart.md) + `docker-compose.dev.yml` + `npm run smoke:dev`                                                      | zero-credential stack; first-run Docker + smoke + examples validated locally |
 | Examples (runnable)    | [`examples/a2a-collab`](examples/a2a-collab), [`examples/swap-planner`](examples/swap-planner), [`examples/delegation-chain`](examples/delegation-chain) | zero-dep Node scripts                                                   |
 | Staging demo           | https://agentfi-develop.up.railway.app                                                                                                                   | Running, **no SLA**                                                     |
 | Docs set               | `VISION.md`, `STATE.md`, `HANDOFF.md`, `docs/`                                                                                                           | live (archive in `docs/_archive/`)                                      |
@@ -231,7 +231,6 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 
 ## 9. Current pending work (details in HANDOFF.md)
 
-- **Verify dev stack + examples end-to-end** (`docker compose -f docker-compose.dev.yml up --build`, `npm run smoke:dev`, then all three `examples/*`) — local Docker was unavailable in the latest session, so CI is green but first-run manual validation is still owed.
 - **GMX / Perp adapter** (Phase 3 close)
 - **On-chain escrow v3** (Phase 3, requires Safe module deploy + audit prep)
 - **Self-funding sub-wallets** (Phase 4, blocked on legal structure decision)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,12 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     restart: unless-stopped
+    command:
+      [
+        'sh',
+        '-lc',
+        'npx prisma migrate deploy --schema=src/db/schema.prisma && node dist/index.js',
+      ]
     environment:
       NODE_ENV: development
       API_PORT: 3000
@@ -84,6 +90,10 @@ services:
     restart: unless-stopped
     environment:
       AGENTFI_API_URL: http://api:3000
+      # Placeholder so the standalone SSE server can boot before an agent is
+      # registered. Replace with a real agfi_live_* key to call tools through
+      # this container.
+      AGENTFI_API_KEY: dev-mcp-placeholder
       MCP_TRANSPORT: sse
       MCP_PORT: 3002
     ports:

--- a/docs/dev-quickstart.md
+++ b/docs/dev-quickstart.md
@@ -10,8 +10,10 @@
 
 - **Docker** (with Compose v2) — `docker --version` and `docker compose version` both return something.
 - Ports **3000, 3001, 3002, 5432, 6379** available locally.
+- Optional: **Node 22 + npm** if you want to run `npm run smoke:dev` or the
+  example scripts from your host machine.
 
-That's it. No Node install, no npm, no API signups.
+That's it for the Docker stack. No API signups.
 
 ---
 
@@ -105,7 +107,8 @@ npm run smoke:dev
 
 It registers two local agents, publishes a manifest, discovers the provider,
 creates and completes a no-reward A2A job, then reads trust + P&L. This path is
-designed to work on the zero-credential dev stack.
+designed to work on the zero-credential dev stack and requires Node/npm on the
+host.
 
 ---
 

--- a/examples/delegation-chain/index.mjs
+++ b/examples/delegation-chain/index.mjs
@@ -201,7 +201,7 @@ async function main() {
   console.log('\n\x1b[32m✓ Delegation chain completed.\x1b[0m');
   console.log(
     '\nWhat this demonstrates:\n' +
-      '  - Agents discover peers (POST /v1/agents/search)\n' +
+      '  - Agents discover peers (GET /v1/agents/search)\n' +
       '  - Agents publish service manifests (PATCH /v1/agents/me/manifest)\n' +
       '  - Agents hire each other atomically (POST /v1/jobs)\n' +
       '  - Sub-delegation is native — any provider can hire further agents\n' +

--- a/packages/admin/next.config.mjs
+++ b/packages/admin/next.config.mjs
@@ -1,6 +1,14 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  turbopack: {
+    root: join(__dirname, '../..'),
+  },
 };
 
 export default nextConfig;

--- a/packages/backend/src/api/middleware/auth.ts
+++ b/packages/backend/src/api/middleware/auth.ts
@@ -26,12 +26,17 @@ const authPlugin: FastifyPluginCallback = (fastify, _opts, done) => {
 
   fastify.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
     // Skip auth for public / separately-authenticated endpoints
-    if (request.routeOptions?.url?.startsWith('/health')) return;
-    if (request.routeOptions?.url?.startsWith('/admin')) return;
-    if (request.routeOptions?.url?.startsWith('/.well-known')) return;
-    if (request.routeOptions?.url?.startsWith('/v1/public/')) return;
-    if (request.routeOptions?.url === '/v1/billing/webhook') return;
-    if (request.routeOptions?.url?.startsWith('/mcp')) return;
+    const routeUrl = request.routeOptions?.url;
+    if (routeUrl?.startsWith('/health')) return;
+    if (routeUrl?.startsWith('/admin')) return;
+    if (routeUrl?.startsWith('/.well-known')) return;
+    if (routeUrl?.startsWith('/v1/public/')) return;
+    if (routeUrl === '/v1/billing/webhook') return;
+    if (routeUrl === '/v1/agents/search') return;
+    if (routeUrl === '/v1/agents/verify-handshake') return;
+    if (routeUrl === '/v1/agents/:id/manifest') return;
+    if (routeUrl === '/v1/agents/:id/trust-report') return;
+    if (routeUrl?.startsWith('/mcp')) return;
 
     // Agent registration uses the operator API_SECRET, not an agent key
     if (request.routeOptions?.url === '/v1/agents' && request.method === 'POST') {


### PR DESCRIPTION
## Summary
- fix Docker first-run blockers for API migrations, MCP workspace-local deps, admin standalone root/host, and container healthchecks
- align public discovery auth middleware with documented unauthenticated routes
- record successful Docker + smoke + examples validation in handoff docs

## Validation
- docker compose -f docker-compose.dev.yml down -v
- docker compose -f docker-compose.dev.yml up --build -d
- docker compose -f docker-compose.dev.yml ps (all services healthy)
- npm run smoke:dev
- node examples/a2a-collab/index.mjs
- node examples/swap-planner/index.mjs
- node examples/delegation-chain/index.mjs
- npm run typecheck --workspaces --if-present
- npm run test -w packages/backend with local compose DATABASE_URL/REDIS_URL and required dev env