### PR TITLE
Refresh MCP publish handoff

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For _what the project is_, read [STATE.md](STATE.md). For _why_, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: May 2026 · **main SHA** `1869bbc` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server) published; source package `0.4.0` pending publish
+**Last updated**: May 2026 · **main baseline verified** `790c53c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server) published; source package `0.4.0` pending publish due npm auth/passkey recovery
 
 ---
 
@@ -65,7 +65,7 @@ Pending work is split into four buckets. Nothing in `Done` is listed here — th
 | ---------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Update mcp.so listing              | External | [Listing](https://mcp.so/server/agentfi-mcp-server/felippeyann) is live, but its config still showed `@agent_fi/mcp-server@0.2.0` in the latest check. |
 | Awaiting awesome-mcp-servers merge | External | [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091) is still open as of 2026-05-08.                                         |
-| Publish mcp-server v0.4.0          | npm org  | Source package adds `get_my_agent_profile` + `get_my_pnl`; publish requires maintainer npm access.                                             |
+| Publish mcp-server v0.4.0          | npm org  | Source package adds `get_my_agent_profile` + `get_my_pnl`; package is ready, but publish is blocked until npm passkey/auth works. See `packages/mcp-server/RELEASE.md`. |
 | Demo screencast                    | —        | 2-minute Claude Desktop doing a real swap via MCP. Highest remaining non-code leverage.                                                      |
 
 ### 3.2 Technical — unblocked
@@ -100,7 +100,7 @@ The live project state has **completed plumbing but zero users**. Adding more co
 | Tenderly access key                      | Pre-broadcast tx simulation (optional; graceful fallback) | https://dashboard.tenderly.co            |
 | Postgres URL                             | Always                                                    | Local Docker, Neon, Supabase, Railway PG |
 | Redis URL                                | Always                                                    | Local Docker, Upstash, Railway Redis     |
-| npm publish access to `@agent_fi`        | Publishing mcp-server                                     | https://www.npmjs.com (invite-only org)  |
+| npm publish access to `@agent_fi`        | Publishing mcp-server                                     | https://www.npmjs.com (invite-only org; current blocker is passkey/auth recovery) |
 | `gh auth login`                          | PR + release ops                                          | GitHub CLI                               |
 | Etherscan-family API keys                | Contract verification                                     | Per-chain block explorer                 |
 | Funded deployer EOA                      | Contract deployment                                       | Hot wallet with gas                      |

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -9,7 +9,9 @@
 
 ## Where we are right now
 
-`main` and `develop` are aligned at `2b8a20b`.
+`main` and `develop` were verified aligned at baseline `790c53c` before this
+release-state refresh. Use `git rev-parse main develop` for the current exact
+SHAs after subsequent documentation-only merges.
 
 Open GitHub state after the dependency cleanup:
 
@@ -143,7 +145,10 @@ Closed the remaining demo gap where P&L required a REST fallback:
 - `npm run demo:claude-mcp` now points Claude Desktop at the local workspace MCP
   server by default, so the demo can use source tools before npm publish.
 - Manual follow-up: publish `@agent_fi/mcp-server@0.4.0` to npm with
-  maintainer credentials.
+  maintainer credentials. A publish attempt from this machine is blocked by npm
+  auth (`ENEEDAUTH`), and the maintainer's passkey was not accepted. The package
+  is ready; recovery is account-side, documented in
+  `packages/mcp-server/RELEASE.md`.
 
 ---
 
@@ -188,7 +193,8 @@ Current map after the latest sweep:
 
 1. **P0 — MCP adoption surface**: keep Claude/MCP demo fully inside MCP tools.
    `get_my_agent_profile` and `get_my_pnl` are implemented in source; npm
-   publish for `@agent_fi/mcp-server@0.4.0` remains manual.
+   publish for `@agent_fi/mcp-server@0.4.0` remains manual and is currently
+   blocked by npm passkey/auth recovery.
 2. **P1 — External distribution**: mcp.so listing is live but still showed an
    old `@agent_fi/mcp-server@0.2.0` config; awesome-mcp-servers PR #5091 is
    still open.

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the _why_) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project _is_ today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: May 2026 · **main SHA** `1869bbc` · **npm** `@agent_fi/mcp-server@0.3.0` published; source package `0.4.0` pending publish
+**Last updated**: May 2026 · **main baseline verified** `790c53c` · **npm** `@agent_fi/mcp-server@0.3.0` published; source package `0.4.0` pending publish due npm auth/passkey recovery
 
 ---
 
@@ -205,7 +205,7 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Source code            | https://github.com/felippeyann/agentfi                                                                                                                   | Apache 2.0, public                                                      |
 | Release                | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0                                                                                               | v0.1.0 (April 2026)                                                     |
-| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.3.0** published; source package is **v0.4.0** pending npm publish   |
+| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.3.0** published; source package is **v0.4.0** pending npm publish; current blocker is npm auth/passkey recovery |
 | mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0 published                                        |
 | mcp.so listing         | https://mcp.so/server/agentfi-mcp-server/felippeyann                                                                                                     | live; latest check still showed stale `@agent_fi/mcp-server@0.2.0` config |
 | awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091                                                                                                | open (pending maintainer merge)                                         |

--- a/packages/mcp-server/RELEASE.md
+++ b/packages/mcp-server/RELEASE.md
@@ -1,127 +1,162 @@
-# Release Guide — @agent_fi/mcp-server
+# Release Guide - @agent_fi/mcp-server
 
-This document describes how to publish new versions of the MCP server to npm.
+This document describes how to publish the standalone AgentFi MCP server to
+npm.
 
-Current version: **0.2.0**
+Current source version: **0.4.0**
+Current published npm version: **0.3.0**
+Status: **0.4.0 is ready in source, but publish is blocked until an npm account
+with access to the `@agent_fi` org can authenticate.**
 
 ## Prerequisites
 
-- npm account with access to the `@agent_fi` organization
-- `npm login` completed (check with `npm whoami`)
-- Local clone of the `felippeyann/agentfi` repo, on `main` branch, up to date
+- npm account with publish access to the `@agent_fi` organization
+- Local clone of `felippeyann/agentfi`, on `main`, up to date
+- Clean git workspace
+- npm auth completed and verified:
 
-## Publishing a new version
-
-### 1. Bump the version in `package.json`
-
-Follow semver:
-- **Patch** (`0.2.0` → `0.2.1`): bug fixes, doc updates, no behavior changes
-- **Minor** (`0.2.0` → `0.3.0`): new MCP tools or non-breaking additions
-- **Major** (`0.2.0` → `1.0.0`): breaking changes (tool signature changes, removals)
-
-Update `packages/mcp-server/package.json`:
-```json
-"version": "0.3.0"
+```bash
+npm login --scope=@agent_fi
+npm whoami
 ```
 
-### 2. Update the keywords if new protocols are added
+If passkey login fails, use npm account recovery in the browser first. Do not
+force a publish from an unauthenticated or unrelated account; the package scope
+must stay `@agent_fi`.
 
-If new DeFi protocols are wrapped, add them to the `keywords` array:
-```json
-"keywords": ["mcp", "defi", "ethereum", "ai-agents", "uniswap", "aave", "compound", "curve", "erc4626", "yearn"]
-```
-
-### 3. Run the publish sequence
+## Publish 0.4.0
 
 From the repo root:
+
 ```bash
-# Pull latest main
 git checkout main
-git pull origin main
+git pull --ff-only origin main
 
-# Go to the package
-cd packages/mcp-server
-
-# Build the package
-npm run build
-
-# Dry run — inspect what will be published
-npm publish --access public --dry-run
-
-# Publish for real
-npm publish --access public
+npm view @agent_fi/mcp-server version
+npm run build -w packages/mcp-server
+npm publish -w packages/mcp-server --access public --dry-run
+npm publish -w packages/mcp-server --access public
 ```
 
-### 4. Create a git tag and GitHub release
+If npm asks for two-factor authentication:
 
-From the repo root:
 ```bash
-# Tag the release (version-prefixed to avoid collision with root release tags)
-git tag mcp-server-v0.3.0
-git push origin mcp-server-v0.3.0
-
-# Create a GitHub release
-gh release create mcp-server-v0.3.0 \
-  --title "mcp-server v0.3.0" \
-  --notes "See CHANGELOG.md for details"
+npm publish -w packages/mcp-server --access public --otp 123456
 ```
 
-### 5. Verify the publish
+Replace `123456` with the current one-time code from the npm account.
+
+## Tag and GitHub Release
+
+After npm publish succeeds:
+
+```bash
+git tag mcp-server-v0.4.0
+git push origin mcp-server-v0.4.0
+
+gh release create mcp-server-v0.4.0 \
+  --title "mcp-server v0.4.0" \
+  --notes "Adds get_my_agent_profile and get_my_pnl MCP tools. See CHANGELOG.md for details."
+```
+
+## Verify the Publish
 
 ```bash
 npm view @agent_fi/mcp-server version
-# Should output: 0.3.0
+# Expected: 0.4.0
 
 npx @agent_fi/mcp-server --help
-# Should print the CLI help
 ```
 
-## Current tool inventory (v0.2.0)
+Also verify the package metadata page:
 
-16 tools across 6 categories:
+- https://www.npmjs.com/package/@agent_fi/mcp-server
 
-**Wallet & balances (3):** `get_wallet`, `get_balance`, `get_allowances`
+## Versioning
+
+- Patch (`0.4.0` -> `0.4.1`): bug fixes, docs/package metadata, no tool shape changes
+- Minor (`0.4.0` -> `0.5.0`): new MCP tools or non-breaking additions
+- Major/pre-1.0 minor (`0.4.0` -> `0.5.0`): breaking tool signature changes, removals, or renamed tools
+
+For pre-1.0 releases, treat breaking changes as a clean minor bump and keep the
+release focused on that one reason.
+
+## Current Tool Inventory (0.4.0)
+
+28 tools across DeFi execution, A2A collaboration, trust, policy, and P&L.
+
+**Wallet & balances (2):** `get_wallet_info`, `get_token_price`
 
 **Swaps (3):** `simulate_swap`, `execute_swap`, `swap_curve`
 
-**Transfers (1):** `execute_transfer`
+**Transfers (1):** `transfer_token`
 
-**Yield — Aave V3 (2):** `supply_aave`, `withdraw_aave`
+**Yield - Aave V3 (3):** `deposit_aave`, `withdraw_aave`, `get_defi_rates`
 
-**Yield — Compound V3 (2):** `supply_compound`, `withdraw_compound`
+**Yield - Compound V3 (2):** `supply_compound`, `withdraw_compound`
 
-**Yield — ERC-4626 generic (2):** `deposit_erc4626`, `withdraw_erc4626`
+**Yield - ERC-4626 generic (2):** `deposit_erc4626`, `withdraw_erc4626`
 
-**Transaction status (2):** `get_transaction_status`, `list_transactions`
+**Transaction status and policy (2):** `get_transaction_status`, `get_policy`
 
-**Agent policy (1):** `get_agent_policy`
+**Agent-to-Agent economy (13):** `get_my_agent_profile`, `get_my_pnl`,
+`search_agents`, `get_agent_manifest`, `set_my_manifest`,
+`get_agent_trust_report`, `post_job`, `check_inbox`, `update_job_status`,
+`pay_agent`, `update_policy`, `sign_handshake`, `verify_handshake`
 
 ## Troubleshooting
 
-### `npm publish` returns 404
+### `npm publish` returns `ENEEDAUTH`
 
-The org `@agent_fi` may not exist yet on your npm account.  Create it at https://www.npmjs.com/org/create.
+The machine is not logged in to npm. Run:
 
-### Authentication fails
+```bash
+npm login --scope=@agent_fi
+npm whoami
+```
 
-Run `npm login` and complete the browser flow. Verify with `npm whoami`.
+If passkey login fails, recover the npm account/passkey in the npm website. This
+is an account-level blocker, not a repo or package problem.
 
-### Typescript build fails
+### `npm publish` returns `E403`
 
-Run `npm ci && npm run typecheck` from repo root first to catch upstream issues.
+The authenticated account does not have publish access to `@agent_fi`. Add the
+account to the npm organization/package with publish rights, then retry.
 
-## Submitting to MCP directories
+### `npm publish` returns `EOTP`
 
-After publishing to npm, submit the package to discovery directories:
+The account requires 2FA for publish. Re-run with `--otp <code>`.
 
-1. **mcp.so** — https://mcp.so/submit
-2. **Smithery** — https://smithery.ai/submit
-3. **awesome-mcp-servers** — https://github.com/punkpeye/awesome-mcp-servers — open a PR adding AgentFi to the DeFi/Finance section
+### `npm publish` returns `404`
+
+The package scope is not visible to the authenticated account, or the org/package
+permissions are wrong. Confirm the package page and org access in npm.
+
+### TypeScript build fails
+
+Run from the repo root:
+
+```bash
+npm ci
+npm run typecheck --workspaces --if-present
+npm run build -w packages/mcp-server
+```
+
+## Directory Follow-Ups
+
+After `0.4.0` is published:
+
+1. Update the mcp.so listing so the install config no longer points at the stale
+   `@agent_fi/mcp-server@0.2.0` package reference.
+2. Check https://github.com/punkpeye/awesome-mcp-servers/pull/5091 and update
+   the PR if maintainers request changes.
 
 Suggested listing:
 
 - **Name:** AgentFi MCP Server
 - **Package:** `@agent_fi/mcp-server`
-- **Description:** Crypto transaction tools for AI agents — swaps (Uniswap, Curve), yield (Aave, Compound, ERC-4626), transfers, and wallet management on Ethereum/Base/Arbitrum/Polygon
+- **Description:** Crypto transaction and A2A economy tools for AI agents:
+  swaps, yield, transfers, policy, trust, jobs, and P&L on Ethereum/Base/
+  Arbitrum/Polygon
 - **GitHub:** https://github.com/felippeyann/agentfi
 - **npm:** https://www.npmjs.com/package/@agent_fi/mcp-server

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,7 +2,7 @@
   "name": "@agent_fi/mcp-server",
   "version": "0.4.0",
   "license": "Apache-2.0",
-  "repository": { "type": "git", "url": "https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },
+  "repository": { "type": "git", "url": "git+https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },
   "description": "AgentFi MCP Server — crypto transaction tools for AI agents",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- refresh MCP release guide for source version `0.4.0` and current npm `0.3.0`
- document npm auth/passkey recovery as the current publish blocker
- update state/handoff/session notes to avoid stale exact SHA drift
- normalize MCP package repository metadata so npm publish no longer autocorrects it

## Validation
- `npm run build -w packages/mcp-server`
- `npm publish -w packages/mcp-server --access public --dry-run`
- `git diff --check`

## Note
Actual npm publish remains blocked by account authentication: `npm whoami` returns `ENEEDAUTH`, and maintainer passkey login was not accepted.