### PR TITLE
docs: refresh project state after mcp-server 0.4.0 publish

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For _what the project is_, read [STATE.md](STATE.md). For _why_, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: May 2026 · **main baseline verified** `790c53c` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.3.0`](https://www.npmjs.com/package/@agent_fi/mcp-server) published; source package `0.4.0` pending publish due npm auth/passkey recovery
+**Last updated**: 2026-05-10 · **main baseline verified** `7270d58` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.4.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
 
 ---
 
@@ -63,9 +63,8 @@ Pending work is split into four buckets. Nothing in `Done` is listed here — th
 
 | Task                               | Blocker  | Notes                                                                                                                                        |
 | ---------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Update mcp.so listing              | External | [Listing](https://mcp.so/server/agentfi-mcp-server/felippeyann) is live, but its config still showed `@agent_fi/mcp-server@0.2.0` in the latest check. |
-| Awaiting awesome-mcp-servers merge | External | [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091) is still open as of 2026-05-08.                                         |
-| Publish mcp-server v0.4.0          | npm org  | Source package adds `get_my_agent_profile` + `get_my_pnl`; package is ready, but publish is blocked until npm passkey/auth works. See `packages/mcp-server/RELEASE.md`. |
+| Update mcp.so listing              | External | [Listing](https://mcp.so/server/agentfi-mcp-server/felippeyann) is live, but its config still pointed at `@agent_fi/mcp-server@0.2.0` as of 2026-05-08. Update to `0.4.0`. |
+| Awaiting awesome-mcp-servers merge | External | [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091) open. Maintainer requested Glama badge on 2026-04-24 — submit server at https://glama.ai/mcp/servers, then add `[![felippeyann/agentfi MCP server](https://glama.ai/mcp/servers/felippeyann/agentfi/badges/score.svg)](https://glama.ai/mcp/servers/felippeyann/agentfi)` to the PR description. |
 | Demo screencast                    | —        | 2-minute Claude Desktop doing a real swap via MCP. Highest remaining non-code leverage.                                                      |
 
 ### 3.2 Technical — unblocked
@@ -100,7 +99,7 @@ The live project state has **completed plumbing but zero users**. Adding more co
 | Tenderly access key                      | Pre-broadcast tx simulation (optional; graceful fallback) | https://dashboard.tenderly.co            |
 | Postgres URL                             | Always                                                    | Local Docker, Neon, Supabase, Railway PG |
 | Redis URL                                | Always                                                    | Local Docker, Upstash, Railway Redis     |
-| npm publish access to `@agent_fi`        | Publishing mcp-server                                     | https://www.npmjs.com (invite-only org; current blocker is passkey/auth recovery) |
+| npm publish access to `@agent_fi`        | Publishing mcp-server                                     | https://www.npmjs.com (invite-only org)                                          |
 | `gh auth login`                          | PR + release ops                                          | GitHub CLI                               |
 | Etherscan-family API keys                | Contract verification                                     | Per-chain block explorer                 |
 | Funded deployer EOA                      | Contract deployment                                       | Hot wallet with gas                      |

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -1,4 +1,4 @@
-# Session Notes — 2026-05-08
+# Session Notes — 2026-05-10
 
 > Single-point handoff doc. Update on every substantive session, prune stale
 > sections aggressively. If this file is older than a few days when you read
@@ -143,12 +143,13 @@ Closed the remaining demo gap where P&L required a REST fallback:
   `get_my_agent_profile` and `get_my_pnl`.
 - Backend embedded `/mcp/sse` proxy exposes matching tools.
 - `npm run demo:claude-mcp` now points Claude Desktop at the local workspace MCP
-  server by default, so the demo can use source tools before npm publish.
-- Manual follow-up: publish `@agent_fi/mcp-server@0.4.0` to npm with
-  maintainer credentials. A publish attempt from this machine is blocked by npm
-  auth (`ENEEDAUTH`), and the maintainer's passkey was not accepted. The package
-  is ready; recovery is account-side, documented in
-  `packages/mcp-server/RELEASE.md`.
+  server by default; can switch back to the published package at any time.
+
+### npm publish 0.4.0 (2026-05-10)
+
+`@agent_fi/mcp-server@0.4.0` is live on npm with `dist-tags.latest=0.4.0`. Tag
+`mcp-server-v0.4.0` pushed and [GitHub release](https://github.com/felippeyann/agentfi/releases/tag/mcp-server-v0.4.0)
+created. The previous npm passkey/auth blocker is resolved.
 
 ---
 
@@ -191,16 +192,14 @@ priority is adoption surface polish, not large protocol expansion.
 
 Current map after the latest sweep:
 
-1. **P0 — MCP adoption surface**: keep Claude/MCP demo fully inside MCP tools.
-   `get_my_agent_profile` and `get_my_pnl` are implemented in source; npm
-   publish for `@agent_fi/mcp-server@0.4.0` remains manual and is currently
-   blocked by npm passkey/auth recovery.
-2. **P1 — External distribution**: mcp.so listing is live but still showed an
-   old `@agent_fi/mcp-server@0.2.0` config; awesome-mcp-servers PR #5091 is
-   still open.
-3. **P2 — Demo screencast**: record the Claude Desktop flow now that the helper
+1. **P0 — External distribution**: update mcp.so listing config (still pointed
+   at stale `@agent_fi/mcp-server@0.2.0`) to `0.4.0`; unblock
+   awesome-mcp-servers [PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091)
+   by submitting the server to https://glama.ai/mcp/servers and adding the
+   Glama score badge to the PR description (maintainer requested 2026-04-24).
+2. **P1 — Demo screencast**: record the Claude Desktop flow now that the helper
    and MCP P&L tool exist.
-4. **P3 — Large roadmap**: GMX/perps, escrow v3, and revenue sharing should
+3. **P2 — Large roadmap**: GMX/perps, escrow v3, and revenue sharing should
    wait for concrete user/integration signal.
 
 ---
@@ -213,4 +212,4 @@ Large roadmap work such as GMX/perps, escrow v3, and revenue sharing should stil
 
 ---
 
-_Last touch: 2026-05-08 (P0 diagnostic session)._
+_Last touch: 2026-05-10 (mcp-server 0.4.0 publish)._

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the _why_) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project _is_ today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: May 2026 · **main baseline verified** `790c53c` · **npm** `@agent_fi/mcp-server@0.3.0` published; source package `0.4.0` pending publish due npm auth/passkey recovery
+**Last updated**: 2026-05-10 · **main baseline verified** `7270d58` · **npm** `@agent_fi/mcp-server@0.4.0` published
 
 ---
 
@@ -205,8 +205,8 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Source code            | https://github.com/felippeyann/agentfi                                                                                                                   | Apache 2.0, public                                                      |
 | Release                | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0                                                                                               | v0.1.0 (April 2026)                                                     |
-| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.3.0** published; source package is **v0.4.0** pending npm publish; current blocker is npm auth/passkey recovery |
-| mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0 published                                        |
+| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.4.0** published (2026-05-10), `dist-tags.latest=0.4.0` |
+| mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0, mcp-server-v0.4.0 published                     |
 | mcp.so listing         | https://mcp.so/server/agentfi-mcp-server/felippeyann                                                                                                     | live; latest check still showed stale `@agent_fi/mcp-server@0.2.0` config |
 | awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091                                                                                                | open (pending maintainer merge)                                         |
 | Base contracts         | `0x03af…6A6d` + `0x5441…24b3`                                                                                                                            | verified on Basescan                                                    |

--- a/packages/mcp-server/RELEASE.md
+++ b/packages/mcp-server/RELEASE.md
@@ -4,9 +4,8 @@ This document describes how to publish the standalone AgentFi MCP server to
 npm.
 
 Current source version: **0.4.0**
-Current published npm version: **0.3.0**
-Status: **0.4.0 is ready in source, but publish is blocked until an npm account
-with access to the `@agent_fi` org can authenticate.**
+Current published npm version: **0.4.0**
+Status: **0.4.0 published 2026-05-10. Tag `mcp-server-v0.4.0` and GitHub release live.**
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Updates the docs triad (HANDOFF, STATE, SESSION_NOTES) and RELEASE.md to reflect the post-0.4.0-publish reality:

- `@agent_fi/mcp-server@0.4.0` published 2026-05-10, `dist-tags.latest=0.4.0`
- Tag `mcp-server-v0.4.0` and GitHub release live
- npm passkey/auth blocker resolved
- main baseline bumped `790c53c` → `7270d58`
- `§3.1` of HANDOFF and current P0s of SESSION_NOTES rewritten to surface the remaining manual tasks (mcp.so listing config update, Glama submission for awesome-mcp-servers PR #5091, demo screencast)

## Test plan

- [x] HANDOFF.md and STATE.md headers — versions and SHAs match repo state
- [x] `npm view @agent_fi/mcp-server version` returns `0.4.0` and matches RELEASE.md
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)