### PR TITLE
chore: fix LICENSE detection and add Glama-targeted Dockerfile

### DIFF
--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -1,0 +1,35 @@
+# Dockerfile dedicated to the Glama MCP registry build.
+#
+# Glama only needs the server to start and respond to MCP introspection
+# (`initialize` + `tools/list`) over stdio, with no credentials.
+# This image runs the published mcp-server in stdio mode — no HTTP, no
+# SSE, no AGENTFI_API_KEY required for the introspection pass.
+#
+# For local SSE / hosted deployments, use Dockerfile.mcp instead.
+
+FROM node:20-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json package-lock.json* ./
+COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
+RUN npm ci --workspace=packages/mcp-server --include-workspace-root
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/mcp-server/node_modules ./packages/mcp-server/node_modules
+COPY tsconfig.base.json ./tsconfig.base.json
+COPY packages/mcp-server ./packages/mcp-server
+RUN cd packages/mcp-server && npm run build
+
+FROM base AS runner
+ENV NODE_ENV=production
+WORKDIR /app/packages/mcp-server
+COPY --from=builder /app/packages/mcp-server/dist ./dist
+COPY --from=builder /app/node_modules ../../node_modules
+COPY --from=builder /app/packages/mcp-server/node_modules ./node_modules
+RUN addgroup -g 1001 appuser && adduser -D -u 1001 -G appuser appuser
+USER appuser
+
+CMD ["node", "dist/index.js"]

--- a/LICENSE
+++ b/LICENSE
@@ -163,6 +163,17 @@
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
    Copyright 2026 AgentFi Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary

Two changes to unblock the [awesome-mcp-servers PR #5091](https://github.com/punkpeye/awesome-mcp-servers/pull/5091), which requires the server to pass Glama checks first. Glama currently reports `License: not found` and `cannot be installed` for `felippeyann/agentfi`.

- **LICENSE** — adds the standard Apache 2.0 APPENDIX block between `END OF TERMS AND CONDITIONS` and the project copyright. Without it, GitHub's `licensee` classifies the file as `NOASSERTION` (`spdx_id: NOASSERTION`), which propagates to Glama as `License: not found`. The boilerplate inserted is verbatim from the Apache 2.0 template.
- **Dockerfile.glama** — variant of `Dockerfile.mcp` dedicated to the Glama introspection build. Drops `EXPOSE 3002` and the `HEALTHCHECK` that probes `:3002/health`, since Glama only needs the server to start in stdio mode and respond to MCP introspection (`initialize` + `tools/list`), with no `AGENTFI_API_KEY` required. Production SSE deploys keep using `Dockerfile.mcp` unchanged.

## Test plan

- [ ] After merge, re-submit the server on Glama pointing at `Dockerfile.glama`; expect license to be detected as Apache 2.0 and introspection to succeed (`Quality: tested`)
- [ ] Once Glama checks are green, add the Glama score badge to PR #5091 and request review

Local Docker build of `Dockerfile.glama` was not run in this session because Docker Desktop wasn't available; changes are minimal vs `Dockerfile.mcp` which builds clean (3 lines removed: `EXPOSE 3002`, the `HEALTHCHECK` line, and its CMD continuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)