### PR TITLE
fix(docs,backend): point all references at the live Fly.io backend

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -214,7 +214,7 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 | Brand avatar           | `.github/avatar.svg`                                                                                                                                     | live                                                                    |
 | Dev quickstart         | [`docs/dev-quickstart.md`](docs/dev-quickstart.md) + `docker-compose.dev.yml` + `npm run smoke:dev`                                                      | zero-credential stack; first-run Docker + smoke + examples validated locally |
 | Examples (runnable)    | [`examples/a2a-collab`](examples/a2a-collab), [`examples/swap-planner`](examples/swap-planner), [`examples/delegation-chain`](examples/delegation-chain) | zero-dep Node scripts                                                   |
-| Staging demo           | https://agentfi-develop.up.railway.app                                                                                                                   | Running, **no SLA**                                                     |
+| Staging demo           | https://agentfi-backend.fly.dev                                                                                                                          | Running on Fly.io (region `gru`), **no SLA**                            |
 | Docs set               | `VISION.md`, `STATE.md`, `HANDOFF.md`, `docs/`                                                                                                           | live (archive in `docs/_archive/`)                                      |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,4 +50,4 @@ Welcome to the AgentFi documentation. This hub is designed for both human operat
 - **Repository**: [felippeyann/agentfi](https://github.com/felippeyann/agentfi)
 - **npm**: [@agent_fi/mcp-server](https://www.npmjs.com/package/@agent_fi/mcp-server)
 - **License**: Apache 2.0
-- **Staging demo**: `https://agentfi-develop.up.railway.app` (no SLA — demo only)
+- **Staging demo**: `https://agentfi-backend.fly.dev` (Fly.io, no SLA — demo only)

--- a/docs/agents/claude-instructions.md
+++ b/docs/agents/claude-instructions.md
@@ -690,8 +690,8 @@ GET /.well-known/agent.json
   "capabilities": ["swap", "transfer", "lending", "balance"],
   "networks": [1, 8453, 42161, 137],
   "authentication": "api_key",
-  "mcp_endpoint": "https://mcp.agentfi.xyz/sse",
-  "openapi": "https://api.agentfi.xyz/openapi.json"
+  "mcp_endpoint": "https://agentfi-backend.fly.dev/mcp/sse",
+  "openapi": "https://agentfi-backend.fly.dev/openapi.json"
 }
 ```
 

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -13,7 +13,7 @@ For Claude Desktop, the lowest-friction path is the local stdio MCP server:
       "command": "npx",
       "args": ["-y", "@agent_fi/mcp-server"],
       "env": {
-        "AGENTFI_API_URL": "https://agentfi-develop.up.railway.app",
+        "AGENTFI_API_URL": "https://agentfi-backend.fly.dev",
         "AGENTFI_API_KEY": "agfi_live_your_key_here"
       }
     }
@@ -38,7 +38,7 @@ cd packages/mcp-server && npm run dev
 ## 2. Register an Agent (get your API key)
 
 ```bash
-curl -X POST https://agentfi-develop.up.railway.app/v1/agents \
+curl -X POST https://agentfi-backend.fly.dev/v1/agents \
   -H "Content-Type: application/json" \
   -d '{"name": "my-agent", "chainIds": [1, 8453]}'
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # AgentFi API Reference
 
-Base URL: `https://api.agentfi.cc` (production) or `http://localhost:3000` (local)
+Base URL: `https://agentfi-backend.fly.dev` (staging demo, no SLA) or `http://localhost:3000` (local)
 
 > **Machine-readable spec**: [`docs/api/openapi.yaml`](api/openapi.yaml) — OpenAPI 3.0.3.
 > Use it with Postman, Insomnia, `openapi-typescript`, `openapi-generator`, or

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -29,8 +29,8 @@ info:
     url: https://github.com/felippeyann/agentfi
 
 servers:
-  - url: https://api.agentfi.cc
-    description: Production
+  - url: https://agentfi-backend.fly.dev
+    description: Staging demo (Fly.io, no SLA)
   - url: http://localhost:3000
     description: Local development
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -69,7 +69,7 @@ Built on top of the transaction pipeline:
 
 ## Deployment posture
 
-AgentFi is **self-hosted by design** (see VISION.md). There is no canonical production instance; operators run their own. A staging demo runs at `https://agentfi-develop.up.railway.app` with no SLA. For self-host deployment see [`docs/operations/production-deploy.md`](../operations/production-deploy.md) (provider-agnostic, Railway reference example).
+AgentFi is **self-hosted by design** (see VISION.md). There is no canonical production instance; operators run their own. A staging demo runs at `https://agentfi-backend.fly.dev` (Fly.io, region `gru`) with no SLA. For self-host deployment see [`docs/operations/production-deploy.md`](../operations/production-deploy.md) (provider-agnostic, Fly.io reference example).
 
 ## Deployed Contracts (Base Mainnet — Chain 8453)
 

--- a/packages/adapters/src/client.ts
+++ b/packages/adapters/src/client.ts
@@ -13,7 +13,7 @@ export class AgentFiClient {
 
   constructor(config: AgentFiConfig) {
     this.apiKey = config.apiKey;
-    this.apiUrl = config.apiUrl ?? 'https://api.agentfi.xyz';
+    this.apiUrl = config.apiUrl ?? 'https://agentfi-backend.fly.dev';
   }
 
   async call<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -102,10 +102,10 @@ async function start() {
     capabilities: ['swap', 'transfer', 'lending', 'balance'],
     networks: [1, 8453, 42161, 137],
     authentication: 'api_key',
-    mcp_endpoint: process.env['MCP_SSE_URL'] ?? 'https://mcp.agentfi.cc/mcp/sse',
+    mcp_endpoint: process.env['MCP_SSE_URL'] ?? 'https://agentfi-backend.fly.dev/mcp/sse',
     openapi: process.env['API_URL']
       ? `${process.env['API_URL']}/openapi.json`
-      : 'https://api.agentfi.cc/openapi.json',
+      : 'https://agentfi-backend.fly.dev/openapi.json',
   }));
 
   // Start BullMQ worker — non-fatal if Redis is temporarily unavailable


### PR DESCRIPTION
## Summary

The Railway staging (`agentfi-develop.up.railway.app`) was retired and the backend now lives at `agentfi-backend.fly.dev` (Fly.io, region `gru` — see `fly.toml`). Until this PR, `scripts/e2e-issue-81.mjs` was the **only file** carrying the live URL; every other doc and source default pointed at the dead Railway endpoint or at unreachable `api.agentfi.cc` / `api.agentfi.xyz` aliases.

That meant a new user following the [Agent Quickstart](../docs/agents/quickstart.md) — copy the JSON snippet, run `npx @agent_fi/mcp-server`, hit a tool — would land in 404 territory immediately. This PR fixes that.

## What changed

9 files, +13/-13 lines (symmetric replacements):

- `STATE.md`, `docs/README.md`, `docs/architecture/overview.md` — staging-demo callouts now point at Fly.io
- `docs/api-reference.md`, `docs/api/openapi.yaml` — Base URL / `servers:` entry
- `docs/agents/quickstart.md` — both env-var snippet and the `curl` register-agent example
- `docs/agents/claude-instructions.md` — `.well-known/agent.json` example values
- `packages/adapters/src/client.ts` — `apiUrl` default fallback
- `packages/backend/src/index.ts` — `.well-known/agent.json` defaults (`mcp_endpoint`, `openapi`)

`fly.toml` is unchanged.

## Verification

- `curl https://agentfi-backend.fly.dev/health` returns `{"status":"ok"}` (verified during this session)
- `grep` for any remaining stale URL returns zero matches across the tree (excluding `graphify-out/` which is auto-generated)
- No code logic changes — only string literals (defaults + docs); CI typecheck/lint expected to stay green

## Out of scope (follow-ups)

- **Custom domain `api.agentfi.cc`**: DNS still points at the dead Railway. Needs a CNAME → `agentfi-backend.fly.dev` on the registrar side, then a follow-up PR to swap the Fly URL for the custom domain in these same files.
- **`/v1/agents/search` returns 401 on Fly** (expected to be public per the recent middleware change). Worth a separate investigation — could be a stale Fly deploy or a middleware-skip regression.
- **`graphify-out/` snapshots** still contain old URLs. Will refresh on next `graphify` regen — no human-facing surface depends on these snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)