### PR TITLE
chore(mcp-server): bump to 0.5.0 — GMX tools, 31 total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (2026-05-13 — Phase 3/4 roadmap)
+## [0.5.0] — 2026-05-15
+
+### Added (Phase 3/4 roadmap — merged 2026-05-13)
 
 - **GMX V2 Synthetics adapter** — `gmx.service.ts` with market data, execution fee calculation, and market resolution for Arbitrum. `buildGmxCreateOrder()` in the transaction builder encodes ExchangeRouter multicall for MarketIncrease/Decrease and LimitIncrease/Decrease orders. Two new routes (`POST /v1/transactions/gmx-open`, `POST /v1/transactions/gmx-close`) and three MCP tools (`list_gmx_markets`, `open_gmx_position`, `close_gmx_position`). Schema: `GMX_OPEN`, `GMX_CLOSE` added to `TxType` enum (migration 0011). GMX contract addresses configured for Arbitrum (42161).
 - **EscrowModule.sol** — on-chain custody contract for A2A job payments. Supports ETH and ERC-20 lock/release/refund with operator-only settlement (mirrors AgentPolicyModule trust model). 22 Foundry tests pass including 3 fuzz tests (256 runs each). Deploy.s.sol updated to deploy EscrowModule alongside existing contracts.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Live pending tasks, credentials inventory, and working conventions. For _what the project is_, read [STATE.md](STATE.md). For _why_, read [VISION.md](VISION.md). This file is the shortest path from "resuming work" → "executing something useful."
 
-**Last updated**: 2026-05-10 · **main baseline verified** `7270d58` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.4.0`](https://www.npmjs.com/package/@agent_fi/mcp-server)
+**Last updated**: 2026-05-15 · **main baseline verified** `5f181fc` · **Repo**: https://github.com/felippeyann/agentfi (public, Apache 2.0) · **Release**: [v0.1.0](https://github.com/felippeyann/agentfi/releases/tag/v0.1.0) · **npm**: [`@agent_fi/mcp-server@0.4.0`](https://www.npmjs.com/package/@agent_fi/mcp-server) → **0.5.0 pending publish**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All project documentation is organized in our **[Documentation Hub](docs/README.
 
 - **Turnkey MPC Wallets** — keys split across shards and never exposed.
 - **Safe Smart Wallets** — per-agent on-chain policy enforcement (limits, whitelists, kill switch).
-- **Model Context Protocol** — 28 tools in [`@agent_fi/mcp-server`](https://www.npmjs.com/package/@agent_fi/mcp-server): DeFi execution, A2A collaboration, trust, and P&L.
+- **Model Context Protocol** — 31 tools in [`@agent_fi/mcp-server`](https://www.npmjs.com/package/@agent_fi/mcp-server): DeFi execution, GMX perpetuals, A2A collaboration, trust, and P&L.
 - **DeFi coverage** — Uniswap V3 + Curve StableSwap (swaps); Aave V3, Compound V3, and any ERC-4626 vault (yield).
 - **Agent-to-Agent economy** — job queue, atomic payments, DB-level escrow (v2), reputation scoring from real metrics with time-decay.
 - **Agent P&L dashboard** — per-agent breakeven detection, including real gas costs (v2).

--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,7 @@
 > **Read together with [VISION.md](VISION.md) (the _why_) and [HANDOFF.md](HANDOFF.md) (live pending tasks).**
 > This file is the **comprehensive, point-in-time snapshot** of what the project _is_ today — purpose, stack, capabilities, progress. Update it whenever the scope or architecture shifts.
 
-**Last updated**: 2026-05-10 · **main baseline verified** `7270d58` · **npm** `@agent_fi/mcp-server@0.4.0` published
+**Last updated**: 2026-05-15 · **main baseline verified** `5f181fc` · **npm** `@agent_fi/mcp-server@0.4.0` published · **0.5.0 pending publish** (31 tools)
 
 ---
 
@@ -30,7 +30,7 @@ AgentFi is the **economic infrastructure for non-human intelligence**. Open-sour
 ```
 ┌─────────────────────────────────────────────────┐
 │  L4  MCP Server / Agent Interface Layer         │
-│  28 structured tools (DeFi + A2A + P&L)         │
+│  31 structured tools (DeFi + GMX + A2A + P&L)   │
 │  stdio (local) + SSE (hosted) transports        │
 ├─────────────────────────────────────────────────┤
 │  L3  Backend API (Fastify v5)                   │
@@ -205,8 +205,8 @@ In parallel, the daily reputation cron will fold this outcome into the agent's s
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Source code            | https://github.com/felippeyann/agentfi                                                                                                                   | Apache 2.0, public                                                      |
 | Release                | https://github.com/felippeyann/agentfi/releases/tag/v0.1.0                                                                                               | v0.1.0 (April 2026)                                                     |
-| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.4.0** published (2026-05-10), `dist-tags.latest=0.4.0` |
-| mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0, mcp-server-v0.4.0 published                     |
+| mcp-server npm         | https://www.npmjs.com/package/@agent_fi/mcp-server                                                                                                       | **v0.4.0** published (2026-05-10); **v0.5.0 pending publish** (31 tools) |
+| mcp-server releases    | https://github.com/felippeyann/agentfi/releases                                                                                                          | v0.1.0, v0.2.0, v0.3.0, mcp-server-v0.4.0 published; v0.5.0 pending    |
 | mcp.so listing         | https://mcp.so/server/agentfi-mcp-server/felippeyann                                                                                                     | live; latest check still showed stale `@agent_fi/mcp-server@0.2.0` config |
 | awesome-mcp-servers PR | https://github.com/punkpeye/awesome-mcp-servers/pull/5091                                                                                                | open (pending maintainer merge)                                         |
 | Base contracts         | `0x03af…6A6d` + `0x5441…24b3`                                                                                                                            | verified on Basescan                                                    |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -265,7 +265,7 @@ All admin routes require `x-admin-secret` header. Local-only by default.
 **Backend MCP Proxy Tools** (16):
 `get_wallet`, `get_balance`, `get_allowances`, `simulate_swap`, `execute_swap`, `execute_transfer`, `supply_aave`, `withdraw_aave`, `supply_compound`, `withdraw_compound`, `deposit_erc4626`, `withdraw_erc4626`, `swap_curve`, `get_transaction_status`, `list_transactions`, `get_agent_policy`
 
-> **Note:** The backend's `/mcp/sse` endpoint exposes a **thin 18-tool proxy** for simple HTTP-over-MCP clients, including agent profile and P&L checks. The standalone `@agent_fi/mcp-server` package is richer: **28 tools** including A2A collaboration (`search_agents`, `post_job`, `check_inbox`, `pay_agent`, `get_my_pnl`, etc.) — see [packages/mcp-server/README.md](../packages/mcp-server/README.md) for the full catalog.
+> **Note:** The backend's `/mcp/sse` endpoint exposes a **thin 18-tool proxy** for simple HTTP-over-MCP clients, including agent profile and P&L checks. The standalone `@agent_fi/mcp-server` package is richer: **31 tools** including GMX V2 perpetuals (`list_gmx_markets`, `open_gmx_position`, `close_gmx_position`) and A2A collaboration (`search_agents`, `post_job`, `check_inbox`, `pay_agent`, `get_my_pnl`, etc.) — see [packages/mcp-server/README.md](../packages/mcp-server/README.md) for the full catalog.
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,7 +5,7 @@
 ```
 ┌─────────────────────────────────────────────────┐
 │  LAYER 4 — MCP Server / Agent Interface Layer   │
-│  28 structured tools (DeFi + A2A + P&L)         │
+│  31 structured tools (DeFi + GMX + A2A + P&L)   │
 │  stdio (local) + SSE (hosted) transports        │
 ├─────────────────────────────────────────────────┤
 │  LAYER 3 — Backend API (Fastify 5)              │

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,10 +1,10 @@
 # @agent_fi/mcp-server
 
-MCP server that gives AI agents 28 tools for executing on-chain transactions and participating in the Agent-to-Agent economy across Ethereum, Base, Arbitrum, and Polygon.
+MCP server that gives AI agents 31 tools for executing on-chain transactions and participating in the Agent-to-Agent economy across Ethereum, Base, Arbitrum, and Polygon.
 
 Built on the [Model Context Protocol](https://modelcontextprotocol.io) (MCP) standard. Works with Claude, GPT, and any MCP-compatible client.
 
-## Tools (28 total)
+## Tools (31 total)
 
 ### Wallet & Balances
 

--- a/packages/mcp-server/RELEASE.md
+++ b/packages/mcp-server/RELEASE.md
@@ -3,9 +3,9 @@
 This document describes how to publish the standalone AgentFi MCP server to
 npm.
 
-Current source version: **0.4.0**
+Current source version: **0.5.0**
 Current published npm version: **0.4.0**
-Status: **0.4.0 published 2026-05-10. Tag `mcp-server-v0.4.0` and GitHub release live.**
+Status: **0.5.0 ready to publish. Adds 3 GMX tools (31 total). Tag and release pending.**
 
 ## Prerequisites
 
@@ -23,7 +23,7 @@ If passkey login fails, use npm account recovery in the browser first. Do not
 force a publish from an unauthenticated or unrelated account; the package scope
 must stay `@agent_fi`.
 
-## Publish 0.4.0
+## Publish 0.5.0
 
 From the repo root:
 
@@ -50,19 +50,19 @@ Replace `123456` with the current one-time code from the npm account.
 After npm publish succeeds:
 
 ```bash
-git tag mcp-server-v0.4.0
-git push origin mcp-server-v0.4.0
+git tag mcp-server-v0.5.0
+git push origin mcp-server-v0.5.0
 
-gh release create mcp-server-v0.4.0 \
-  --title "mcp-server v0.4.0" \
-  --notes "Adds get_my_agent_profile and get_my_pnl MCP tools. See CHANGELOG.md for details."
+gh release create mcp-server-v0.5.0 \
+  --title "mcp-server v0.5.0" \
+  --notes "Adds GMX V2 Synthetics tools: list_gmx_markets, open_gmx_position, close_gmx_position. 31 tools total. See CHANGELOG.md for details."
 ```
 
 ## Verify the Publish
 
 ```bash
 npm view @agent_fi/mcp-server version
-# Expected: 0.4.0
+# Expected: 0.5.0
 
 npx @agent_fi/mcp-server --help
 ```
@@ -80,9 +80,9 @@ Also verify the package metadata page:
 For pre-1.0 releases, treat breaking changes as a clean minor bump and keep the
 release focused on that one reason.
 
-## Current Tool Inventory (0.4.0)
+## Current Tool Inventory (0.5.0)
 
-28 tools across DeFi execution, A2A collaboration, trust, policy, and P&L.
+31 tools across DeFi execution, A2A collaboration, trust, policy, and P&L.
 
 **Wallet & balances (2):** `get_wallet_info`, `get_token_price`
 
@@ -95,6 +95,8 @@ release focused on that one reason.
 **Yield - Compound V3 (2):** `supply_compound`, `withdraw_compound`
 
 **Yield - ERC-4626 generic (2):** `deposit_erc4626`, `withdraw_erc4626`
+
+**Perpetuals - GMX V2 (3):** `list_gmx_markets`, `open_gmx_position`, `close_gmx_position`
 
 **Transaction status and policy (2):** `get_transaction_status`, `get_policy`
 
@@ -143,12 +145,11 @@ npm run build -w packages/mcp-server
 
 ## Directory Follow-Ups
 
-After `0.4.0` is published:
+After `0.5.0` is published:
 
-1. Update the mcp.so listing so the install config no longer points at the stale
-   `@agent_fi/mcp-server@0.2.0` package reference.
-2. Check https://github.com/punkpeye/awesome-mcp-servers/pull/5091 and update
-   the PR if maintainers request changes.
+1. Update the mcp.so listing to reference `@agent_fi/mcp-server@0.5.0` and
+   mention the 3 new GMX tools.
+2. Update awesome-mcp-servers PR #5091 tool count: 28 → 31.
 
 Suggested listing:
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent_fi/mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": { "type": "git", "url": "git+https://github.com/felippeyann/agentfi.git", "directory": "packages/mcp-server" },
   "description": "AgentFi MCP Server — crypto transaction tools for AI agents",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -36,7 +36,7 @@ const toolRegistry = new Map(ALL_TOOLS.map((t) => [t.name, t]));
 const server = new Server(
   {
     name: 'agentfi',
-    version: '0.4.0',
+    version: '0.5.0',
   },
   {
     capabilities: {


### PR DESCRIPTION
## Summary

- Bumps `@agent_fi/mcp-server` `0.4.0` → `0.5.0`
- The 3 GMX V2 Synthetics tools (`list_gmx_markets`, `open_gmx_position`, `close_gmx_position`) landed in `main` via PR #116 (2026-05-13) but were never version-bumped or published to npm
- Tool count: 28 → **31**
- Updates `RELEASE.md` publish runbook (tag, release notes, follow-ups for 0.5.0)
- Adds `[0.5.0]` entry to `CHANGELOG.md`
- Updates tool count references in `README.md`, `STATE.md`, `HANDOFF.md`, `docs/api-reference.md`, `docs/architecture/overview.md`, `packages/mcp-server/README.md`

## After merge

```bash
git checkout main && git pull --ff-only origin main
npm run build -w packages/mcp-server
npm publish -w packages/mcp-server --access public
git tag mcp-server-v0.5.0 && git push origin mcp-server-v0.5.0
gh release create mcp-server-v0.5.0 --title "mcp-server v0.5.0" \
  --notes "Adds GMX V2 Synthetics tools: list_gmx_markets, open_gmx_position, close_gmx_position. 31 tools total."
```

## Test plan

- [x] `npm run build -w packages/mcp-server` — clean
- [x] `npm run typecheck --workspaces --if-present` — all 4 workspaces pass
- [ ] `npm publish --dry-run` after merge (to verify package contents before live push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)